### PR TITLE
Change structure of epp-client to be i/o task based

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,9 +13,9 @@ default = ["tokio-rustls"]
 async-trait = "0.1.52"
 celes = "2.1"
 chrono = { version = "0.4.23", features = ["serde"] }
-quick-xml = { version = "0.26", features = [ "serialize" ] }
+quick-xml = { version = "0.26", features = ["serialize"] }
 serde = { version = "1.0", features = ["derive"] }
-tokio = { version = "1.0", features = [ "full" ] }
+tokio = { version = "1.0", features = ["full"] }
 tokio-rustls = { version = "0.23", optional = true }
 tracing = "0.1.29"
 webpki-roots = "0.22.1"

--- a/src/client.rs
+++ b/src/client.rs
@@ -106,7 +106,7 @@ impl<C: Connector> EppClient<C> {
         let xml = xml::serialize(&HelloDocument::default())?;
 
         debug!("{}: hello: {}", self.connection.registry, &xml);
-        let response = self.connection.transact(&xml)?.await?;
+        let response = self.connection.transact(&xml).await?;
         debug!("{}: greeting: {}", self.connection.registry, &response);
 
         Ok(xml::deserialize::<GreetingDocument>(&response)?.data)
@@ -126,7 +126,7 @@ impl<C: Connector> EppClient<C> {
         let xml = xml::serialize(&document)?;
 
         debug!("{}: request: {}", self.connection.registry, &xml);
-        let response = self.connection.transact(&xml)?.await?;
+        let response = self.connection.transact(&xml).await?;
         debug!("{}: response: {}", self.connection.registry, &response);
 
         let rsp = xml::deserialize::<ResponseDocument<Cmd::Response, Ext::Response>>(&response)?;
@@ -146,7 +146,7 @@ impl<C: Connector> EppClient<C> {
     /// Accepts raw EPP XML and returns the raw EPP XML response to it.
     /// Not recommended for direct use but sometimes can be useful for debugging
     pub async fn transact_xml(&mut self, xml: &str) -> Result<String, Error> {
-        self.connection.transact(xml)?.await
+        self.connection.transact(xml).await
     }
 
     /// Returns the greeting received on establishment of the connection in raw xml form

--- a/src/client.rs
+++ b/src/client.rs
@@ -1,22 +1,10 @@
-use std::io;
-use std::sync::Arc;
 use std::time::Duration;
 
-use async_trait::async_trait;
-#[cfg(feature = "tokio-rustls")]
-use tokio::net::lookup_host;
-use tokio::net::TcpStream;
-#[cfg(feature = "tokio-rustls")]
-use tokio_rustls::client::TlsStream;
-#[cfg(feature = "tokio-rustls")]
-use tokio_rustls::rustls::{ClientConfig, OwnedTrustAnchor, RootCertStore, ServerName};
-#[cfg(feature = "tokio-rustls")]
-use tokio_rustls::TlsConnector;
-use tracing::{debug, error, info};
+use tracing::{debug, error};
 
-use crate::common::{Certificate, NoExtension, PrivateKey};
-pub use crate::connection::Connector;
-use crate::connection::{self, EppConnection};
+use crate::common::NoExtension;
+pub use crate::connect::Connector;
+use crate::connection::EppConnection;
 use crate::error::Error;
 use crate::hello::{Greeting, GreetingDocument, HelloDocument};
 use crate::request::{Command, CommandDocument, Extension, Transaction};
@@ -69,28 +57,6 @@ use crate::xml;
 /// ```
 pub struct EppClient<C: Connector> {
     connection: EppConnection<C>,
-}
-
-#[cfg(feature = "tokio-rustls")]
-impl EppClient<RustlsConnector> {
-    /// Connect to the specified `addr` and `hostname` over TLS
-    ///
-    /// The `registry` is used as a name in internal logging; `host` provides the host name
-    /// and port to connect to), `hostname` is sent as the TLS server name indication and
-    /// `identity` provides optional TLS client authentication (using) rustls as the TLS
-    /// implementation. The `timeout` limits the time spent on any underlying network operations.
-    ///
-    /// Alternatively, use `EppClient::new()` with any established `AsyncRead + AsyncWrite + Unpin`
-    /// implementation.
-    pub async fn connect(
-        registry: String,
-        server: (String, u16),
-        identity: Option<(Vec<Certificate>, PrivateKey)>,
-        timeout: Duration,
-    ) -> Result<Self, Error> {
-        let connector = RustlsConnector::new(server, identity).await?;
-        Self::new(connector, registry, timeout).await
-    }
 }
 
 impl<C: Connector> EppClient<C> {
@@ -204,79 +170,3 @@ impl<'c, 'e, C, E> Clone for RequestData<'c, 'e, C, E> {
 
 // Manual impl because this does not depend on whether `C` and `E` are `Copy`
 impl<'c, 'e, C, E> Copy for RequestData<'c, 'e, C, E> {}
-
-#[cfg(feature = "tokio-rustls")]
-pub struct RustlsConnector {
-    inner: TlsConnector,
-    domain: ServerName,
-    server: (String, u16),
-}
-
-impl RustlsConnector {
-    pub async fn new(
-        server: (String, u16),
-        identity: Option<(Vec<Certificate>, PrivateKey)>,
-    ) -> Result<Self, Error> {
-        let mut roots = RootCertStore::empty();
-        roots.add_server_trust_anchors(webpki_roots::TLS_SERVER_ROOTS.0.iter().map(|ta| {
-            OwnedTrustAnchor::from_subject_spki_name_constraints(
-                ta.subject,
-                ta.spki,
-                ta.name_constraints,
-            )
-        }));
-
-        let builder = ClientConfig::builder()
-            .with_safe_defaults()
-            .with_root_certificates(roots);
-
-        let config = match identity {
-            Some((certs, key)) => {
-                let certs = certs
-                    .into_iter()
-                    .map(|cert| tokio_rustls::rustls::Certificate(cert.0))
-                    .collect();
-                builder
-                    .with_single_cert(certs, tokio_rustls::rustls::PrivateKey(key.0))
-                    .map_err(|e| Error::Other(e.into()))?
-            }
-            None => builder.with_no_client_auth(),
-        };
-
-        let domain = server.0.as_str().try_into().map_err(|_| {
-            io::Error::new(
-                io::ErrorKind::InvalidInput,
-                format!("Invalid domain: {}", server.0),
-            )
-        })?;
-
-        Ok(Self {
-            inner: TlsConnector::from(Arc::new(config)),
-            domain,
-            server,
-        })
-    }
-}
-
-#[cfg(feature = "tokio-rustls")]
-#[async_trait]
-impl Connector for RustlsConnector {
-    type Connection = TlsStream<TcpStream>;
-
-    async fn connect(&self, timeout: Duration) -> Result<Self::Connection, Error> {
-        info!("Connecting to server: {}:{}", self.server.0, self.server.1);
-        let addr = match lookup_host(&self.server).await?.next() {
-            Some(addr) => addr,
-            None => {
-                return Err(Error::Io(io::Error::new(
-                    io::ErrorKind::InvalidInput,
-                    format!("Invalid host: {}", &self.server.0),
-                )))
-            }
-        };
-
-        let stream = TcpStream::connect(addr).await?;
-        let future = self.inner.connect(self.domain.clone(), stream);
-        connection::timeout(timeout, future).await
-    }
-}

--- a/src/client.rs
+++ b/src/client.rs
@@ -16,7 +16,9 @@ use crate::request::{Command, CommandDocument, Extension, Transaction};
 use crate::response::{Response, ResponseDocument, ResponseStatus};
 use crate::xml;
 
-/// An `EppClient` provides an interface to sending EPP requests to a registry
+/// EPP Client
+///
+/// Provides an interface to send EPP requests to a registry
 ///
 /// Once initialized, the [`EppClient`] instance is the API half that is returned when creating a new connection.
 /// It can serialize EPP requests to XML and send them to the registry and deserialize the XML responses from the
@@ -70,7 +72,6 @@ pub struct EppClient {
 }
 
 impl EppClient {
-    /// Create an `EppClient` from an already established connection
     pub(crate) fn new(sender: mpsc::UnboundedSender<Request>, registry: Cow<'static, str>) -> Self {
         Self {
             inner: Arc::new(InnerClient { sender, registry }),
@@ -91,6 +92,9 @@ impl EppClient {
         Ok(xml::deserialize::<GreetingDocument>(&response)?.data)
     }
 
+    /// Sends a EPP request and await its response
+    ///
+    /// The given transactions id is not checked internally when build in release mode.
     pub async fn transact<'c, 'e, Cmd, Ext>(
         &mut self,
         data: impl Into<RequestData<'c, 'e, Cmd, Ext>>,

--- a/src/client.rs
+++ b/src/client.rs
@@ -71,9 +71,12 @@ impl<C: Connector> EppClient<C> {
     pub async fn hello(&mut self) -> Result<Greeting, Error> {
         let xml = xml::serialize(&HelloDocument::default())?;
 
-        debug!("{}: hello: {}", self.connection.registry, &xml);
+        debug!(registry = self.connection.registry, "hello: {}", &xml);
         let response = self.connection.transact(&xml).await?;
-        debug!("{}: greeting: {}", self.connection.registry, &response);
+        debug!(
+            registry = self.connection.registry,
+            "greeting: {}", &response
+        );
 
         Ok(xml::deserialize::<GreetingDocument>(&response)?.data)
     }
@@ -91,9 +94,12 @@ impl<C: Connector> EppClient<C> {
         let document = CommandDocument::new(data.command, data.extension, id);
         let xml = xml::serialize(&document)?;
 
-        debug!("{}: request: {}", self.connection.registry, &xml);
+        debug!(registry = self.connection.registry, "request: {}", &xml);
         let response = self.connection.transact(&xml).await?;
-        debug!("{}: response: {}", self.connection.registry, &response);
+        debug!(
+            registry = self.connection.registry,
+            "response: {}", &response
+        );
 
         let rsp = xml::deserialize::<ResponseDocument<Cmd::Response, Ext::Response>>(&response)?;
         if rsp.data.result.code.is_success() {
@@ -105,7 +111,7 @@ impl<C: Connector> EppClient<C> {
             tr_ids: rsp.data.tr_ids,
         }));
 
-        error!(%response, "Failed to deserialize response for transaction: {}", err);
+        error!(registry=self.connection.registry, %response, "Failed to deserialize response for transaction: {}", err);
         Err(err)
     }
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -1,10 +1,15 @@
-use std::time::Duration;
+use std::borrow::Cow;
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::Arc;
+use std::task::{Context, Poll};
 
+use tokio::sync::mpsc;
 use tracing::{debug, error};
 
 use crate::common::NoExtension;
 pub use crate::connect::Connector;
-use crate::connection::EppConnection;
+use crate::connection::{Request, RequestMessage};
 use crate::error::Error;
 use crate::hello::{Greeting, GreetingDocument, HelloDocument};
 use crate::request::{Command, CommandDocument, Extension, Transaction};
@@ -13,8 +18,9 @@ use crate::xml;
 
 /// An `EppClient` provides an interface to sending EPP requests to a registry
 ///
-/// Once initialized, the EppClient instance can serialize EPP requests to XML and send them
-/// to the registry and deserialize the XML responses from the registry to local types.
+/// Once initialized, the [`EppClient`] instance is the API half that is returned when creating a new connection.
+/// It can serialize EPP requests to XML and send them to the registry and deserialize the XML responses from the
+/// registry to local types.
 ///
 /// # Examples
 ///
@@ -23,7 +29,7 @@ use crate::xml;
 /// # use std::net::ToSocketAddrs;
 /// # use std::time::Duration;
 /// #
-/// use epp_client::EppClient;
+/// use epp_client::connect::connect;
 /// use epp_client::domain::DomainCheck;
 /// use epp_client::common::NoExtension;
 ///
@@ -31,10 +37,14 @@ use crate::xml;
 /// # async fn main() {
 /// // Create an instance of EppClient
 /// let timeout = Duration::from_secs(5);
-/// let mut client = match EppClient::connect("registry_name".to_string(), ("example.com".to_owned(), 7000), None, timeout).await {
+/// let (mut client, mut connection) = match connect("registry_name".into(), ("example.com".into(), 7000), None, timeout).await {
 ///     Ok(client) => client,
 ///     Err(e) => panic!("Failed to create EppClient: {}",  e)
 /// };
+///
+/// tokio::spawn(async move {
+///     connection.run().await.unwrap();
+/// });
 ///
 /// // Make a EPP Hello call to the registry
 /// let greeting = client.hello().await.unwrap();
@@ -55,26 +65,26 @@ use crate::xml;
 /// Domain: eppdev.com, Available: 1
 /// Domain: eppdev.net, Available: 1
 /// ```
-pub struct EppClient<C: Connector> {
-    connection: EppConnection<C>,
+pub struct EppClient {
+    inner: Arc<InnerClient>,
 }
 
-impl<C: Connector> EppClient<C> {
+impl EppClient {
     /// Create an `EppClient` from an already established connection
-    pub async fn new(connector: C, registry: String, timeout: Duration) -> Result<Self, Error> {
-        Ok(Self {
-            connection: EppConnection::new(connector, registry, timeout).await?,
-        })
+    pub(crate) fn new(sender: mpsc::UnboundedSender<Request>, registry: Cow<'static, str>) -> Self {
+        Self {
+            inner: Arc::new(InnerClient { sender, registry }),
+        }
     }
 
     /// Executes an EPP Hello call and returns the response as a `Greeting`
     pub async fn hello(&mut self) -> Result<Greeting, Error> {
         let xml = xml::serialize(&HelloDocument::default())?;
 
-        debug!(registry = self.connection.registry, "hello: {}", &xml);
-        let response = self.connection.transact(&xml).await?;
+        debug!(registry = %self.inner.registry, "hello: {}", &xml);
+        let response = self.inner.send(xml)?.await?;
         debug!(
-            registry = self.connection.registry,
+            registry = %self.inner.registry,
             "greeting: {}", &response
         );
 
@@ -94,14 +104,16 @@ impl<C: Connector> EppClient<C> {
         let document = CommandDocument::new(data.command, data.extension, id);
         let xml = xml::serialize(&document)?;
 
-        debug!(registry = self.connection.registry, "request: {}", &xml);
-        let response = self.connection.transact(&xml).await?;
+        debug!(registry = %self.inner.registry, "request: {}", &xml);
+        let response = self.inner.send(xml)?.await?;
         debug!(
-            registry = self.connection.registry,
+            registry = %self.inner.registry,
             "response: {}", &response
         );
 
         let rsp = xml::deserialize::<ResponseDocument<Cmd::Response, Ext::Response>>(&response)?;
+        debug_assert!(rsp.data.tr_ids.client_tr_id.as_deref() == Some(id));
+
         if rsp.data.result.code.is_success() {
             return Ok(rsp.data);
         }
@@ -111,32 +123,35 @@ impl<C: Connector> EppClient<C> {
             tr_ids: rsp.data.tr_ids,
         }));
 
-        error!(registry=self.connection.registry, %response, "Failed to deserialize response for transaction: {}", err);
+        error!(
+            registry = %self.inner.registry,
+            %response,
+            "Failed to deserialize response for transaction: {}", err
+        );
         Err(err)
     }
 
     /// Accepts raw EPP XML and returns the raw EPP XML response to it.
     /// Not recommended for direct use but sometimes can be useful for debugging
-    pub async fn transact_xml(&mut self, xml: &str) -> Result<String, Error> {
-        self.connection.transact(xml).await
+    pub async fn transact_xml(&mut self, xml: String) -> Result<String, Error> {
+        self.inner.send(xml)?.await
     }
 
     /// Returns the greeting received on establishment of the connection in raw xml form
-    pub fn xml_greeting(&self) -> String {
-        String::from(&self.connection.greeting)
+    pub async fn xml_greeting(&self) -> Result<String, Error> {
+        self.inner.xml_greeting().await
     }
 
     /// Returns the greeting received on establishment of the connection as an `Greeting`
-    pub fn greeting(&self) -> Result<Greeting, Error> {
-        xml::deserialize::<GreetingDocument>(&self.connection.greeting).map(|obj| obj.data)
+    pub async fn greeting(&self) -> Result<Greeting, Error> {
+        let greeting = self.inner.xml_greeting().await?;
+        xml::deserialize::<GreetingDocument>(&greeting).map(|obj| obj.data)
     }
 
-    pub async fn reconnect(&mut self) -> Result<(), Error> {
-        self.connection.reconnect().await
-    }
-
-    pub async fn shutdown(mut self) -> Result<(), Error> {
-        self.connection.shutdown().await
+    /// Reconnects the underlying [`Connector::Connection`]
+    pub async fn reconnect(&self) -> Result<Greeting, Error> {
+        let greeting = self.inner.reconnect().await?;
+        xml::deserialize::<GreetingDocument>(&greeting).map(|obj| obj.data)
     }
 }
 
@@ -176,3 +191,63 @@ impl<'c, 'e, C, E> Clone for RequestData<'c, 'e, C, E> {
 
 // Manual impl because this does not depend on whether `C` and `E` are `Copy`
 impl<'c, 'e, C, E> Copy for RequestData<'c, 'e, C, E> {}
+
+struct InnerClient {
+    sender: mpsc::UnboundedSender<Request>,
+    pub registry: Cow<'static, str>,
+}
+
+impl InnerClient {
+    fn send(&self, request: String) -> Result<InnerResponse, Error> {
+        let (sender, receiver) = mpsc::channel(1);
+        let request = Request {
+            request: RequestMessage::Request(request),
+            sender,
+        };
+        self.sender.send(request).map_err(|_| Error::Closed)?;
+
+        Ok(InnerResponse { receiver })
+    }
+
+    /// Returns the greeting received on establishment of the connection in raw xml form
+    async fn xml_greeting(&self) -> Result<String, Error> {
+        let (sender, receiver) = mpsc::channel(1);
+        let request = Request {
+            request: RequestMessage::Greeting,
+            sender,
+        };
+        self.sender.send(request).map_err(|_| Error::Closed)?;
+
+        InnerResponse { receiver }.await
+    }
+
+    async fn reconnect(&self) -> Result<String, Error> {
+        let (sender, receiver) = mpsc::channel(1);
+        let request = Request {
+            request: RequestMessage::Reconnect,
+            sender,
+        };
+        self.sender.send(request).map_err(|_| Error::Closed)?;
+
+        InnerResponse { receiver }.await
+    }
+}
+
+// We do not need to parse any output at this point (we could do that),
+// but for now we just store the receiver here.
+pub(crate) struct InnerResponse {
+    receiver: mpsc::Receiver<Result<String, Error>>,
+}
+
+impl Future for InnerResponse {
+    type Output = Result<String, Error>;
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        let this = self.get_mut();
+        match this.receiver.poll_recv(cx) {
+            Poll::Ready(Some(response)) => Poll::Ready(response),
+            Poll::Ready(None) => Poll::Ready(Err(Error::Closed)),
+            Poll::Pending => Poll::Pending,
+        }
+    }
+}

--- a/src/client.rs
+++ b/src/client.rs
@@ -37,7 +37,7 @@ use crate::xml;
 /// # async fn main() {
 /// // Create an instance of EppClient
 /// let timeout = Duration::from_secs(5);
-/// let (mut client, mut connection) = match connect("registry_name".into(), ("example.com".into(), 7000), None, timeout).await {
+/// let (mut client, mut connection) = match connect("registry_name".into(), ("example.com".into(), 7000), None, timeout, None).await {
 ///     Ok(client) => client,
 ///     Err(e) => panic!("Failed to create EppClient: {}",  e)
 /// };

--- a/src/connect.rs
+++ b/src/connect.rs
@@ -1,0 +1,149 @@
+use std::sync::Arc;
+use std::time::Duration;
+
+use async_trait::async_trait;
+use tokio::io;
+use tokio::io::AsyncRead;
+use tokio::io::AsyncWrite;
+#[cfg(feature = "tokio-rustls")]
+use tokio::net::lookup_host;
+use tokio::net::TcpStream;
+#[cfg(feature = "tokio-rustls")]
+use tokio_rustls::client::TlsStream;
+#[cfg(feature = "tokio-rustls")]
+use tokio_rustls::rustls::{ClientConfig, OwnedTrustAnchor, RootCertStore, ServerName};
+#[cfg(feature = "tokio-rustls")]
+use tokio_rustls::TlsConnector;
+use tracing::info;
+
+use crate::client::EppClient;
+use crate::common::{Certificate, PrivateKey};
+use crate::connection;
+use crate::error::Error;
+
+/// Connect to the specified `server` and `hostname` over TLS
+///
+/// The `registry` is used as a name in internal logging; `addr` provides the address to
+/// connect to, `hostname` is sent as the TLS server name indication and `identity` provides
+/// optional TLS client authentication (using) rustls as the TLS implementation.
+/// The `timeout` limits the time spent on any underlying network operations.
+///
+/// This returns two halves, a cloneable client and the underlying connection.
+///
+/// Use connect_with_connector for passing a specific connector.
+#[cfg(feature = "tokio-rustls")]
+pub async fn connect(
+    registry: String,
+    server: (String, u16),
+    identity: Option<(Vec<Certificate>, PrivateKey)>,
+    timeout: Duration,
+) -> Result<EppClient<RustlsConnector>, Error> {
+    info!("Connecting to server: {:?}", server);
+
+    let connector = RustlsConnector::new(server, identity).await?;
+    EppClient::new(connector, registry, timeout).await
+}
+
+/// Connect to the specified `server` and `hostname` via the passed connector.
+///
+/// The `registry` is used as a name in internal logging; `addr` provides the address to
+/// connect to, `hostname` is sent as the TLS server name indication and `identity` provides
+/// optional TLS client authentication (using) rustls as the TLS implementation.
+/// The `timeout` limits the time spent on any underlying network operations.
+///
+/// This returns two halves, a cloneable client and the underlying connection.
+///
+/// Use connect_with_connector for passing a specific connector.
+pub async fn connect_with_connector<C>(
+    connector: C,
+    registry: String,
+    timeout: Duration,
+) -> Result<EppClient<C>, Error>
+where
+    C: Connector,
+{
+    EppClient::new(connector, registry, timeout).await
+}
+
+#[cfg(feature = "tokio-rustls")]
+pub struct RustlsConnector {
+    inner: TlsConnector,
+    domain: ServerName,
+    server: (String, u16),
+}
+
+impl RustlsConnector {
+    pub async fn new(
+        server: (String, u16),
+        identity: Option<(Vec<Certificate>, PrivateKey)>,
+    ) -> Result<Self, Error> {
+        let mut roots = RootCertStore::empty();
+        roots.add_server_trust_anchors(webpki_roots::TLS_SERVER_ROOTS.0.iter().map(|ta| {
+            OwnedTrustAnchor::from_subject_spki_name_constraints(
+                ta.subject,
+                ta.spki,
+                ta.name_constraints,
+            )
+        }));
+
+        let builder = ClientConfig::builder()
+            .with_safe_defaults()
+            .with_root_certificates(roots);
+
+        let config = match identity {
+            Some((certs, key)) => {
+                let certs = certs
+                    .into_iter()
+                    .map(|cert| tokio_rustls::rustls::Certificate(cert.0))
+                    .collect();
+                builder
+                    .with_single_cert(certs, tokio_rustls::rustls::PrivateKey(key.0))
+                    .map_err(|e| Error::Other(e.into()))?
+            }
+            None => builder.with_no_client_auth(),
+        };
+
+        let domain = server.0.as_str().try_into().map_err(|_| {
+            io::Error::new(
+                io::ErrorKind::InvalidInput,
+                format!("Invalid domain: {}", server.0),
+            )
+        })?;
+
+        Ok(Self {
+            inner: TlsConnector::from(Arc::new(config)),
+            domain,
+            server,
+        })
+    }
+}
+
+#[cfg(feature = "tokio-rustls")]
+#[async_trait]
+impl Connector for RustlsConnector {
+    type Connection = TlsStream<TcpStream>;
+
+    async fn connect(&self, timeout: Duration) -> Result<Self::Connection, Error> {
+        info!("Connecting to server: {}:{}", self.server.0, self.server.1);
+        let addr = match lookup_host(&self.server).await?.next() {
+            Some(addr) => addr,
+            None => {
+                return Err(Error::Io(io::Error::new(
+                    io::ErrorKind::InvalidInput,
+                    format!("Invalid host: {}", &self.server.0),
+                )))
+            }
+        };
+
+        let stream = TcpStream::connect(addr).await?;
+        let future = self.inner.connect(self.domain.clone(), stream);
+        connection::timeout(timeout, future).await
+    }
+}
+
+#[async_trait]
+pub trait Connector {
+    type Connection: AsyncRead + AsyncWrite + Unpin;
+
+    async fn connect(&self, timeout: Duration) -> Result<Self::Connection, Error>;
+}

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -1,13 +1,11 @@
 //! Manages registry connections and reading/writing to them
 
 use std::future::Future;
-use std::pin::Pin;
-use std::task::{Context, Poll};
 use std::time::Duration;
-use std::{io, mem, str, u32};
+use std::{io, str, u32};
 
 use async_trait::async_trait;
-use tokio::io::{AsyncRead, AsyncWrite, AsyncWriteExt, ReadBuf};
+use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
 use tracing::{debug, info};
 
 use crate::error::Error;
@@ -19,16 +17,8 @@ pub(crate) struct EppConnection<C: Connector> {
     stream: C::Connection,
     pub greeting: String,
     timeout: Duration,
-    // A request that is currently in flight
-    //
-    // Because the code here currently depends on only one request being in flight at a time,
-    // this needs to be finished (written, and response read) before we start another one.
-    current: Option<RequestState>,
-    // The next request to be sent
-    //
-    // If we get a request while another request is in flight (because its future was dropped),
-    // we will store it here until the current request is finished.
-    next: Option<RequestState>,
+    // Whether the connection is in a good state to start sending a request
+    ready: bool,
 }
 
 impl<C: Connector> EppConnection<C> {
@@ -43,258 +33,17 @@ impl<C: Connector> EppConnection<C> {
             connector,
             greeting: String::new(),
             timeout,
-            current: None,
-            next: None,
+            ready: false,
         };
 
-        this.read_greeting().await?;
+        this.greeting = this.get_epp_response().await?;
+        this.ready = true;
         Ok(this)
     }
 
-    async fn read_greeting(&mut self) -> Result<(), Error> {
-        assert!(self.current.is_none());
-        self.current = Some(RequestState::ReadLength {
-            read: 0,
-            buf: vec![0; 256],
-        });
-
-        self.greeting = RequestFuture { conn: self }.await?;
-        Ok(())
-    }
-
-    pub(crate) async fn reconnect(&mut self) -> Result<(), Error> {
-        debug!("{}: reconnecting", self.registry);
-        let _ = self.current.take();
-        let _ = self.next.take();
-        self.stream = self.connector.connect(self.timeout).await?;
-        self.read_greeting().await?;
-        Ok(())
-    }
-
-    /// Sends an EPP XML request to the registry and returns the response
-    pub(crate) fn transact<'a>(&'a mut self, command: &str) -> Result<RequestFuture<'a, C>, Error> {
-        let new = RequestState::new(command)?;
-
-        // If we have a request currently in flight, finish that first
-        // If another request was queued up behind the one in flight, just replace it
-        match self.current.is_some() {
-            true => {
-                debug!(
-                    "{}: Queueing up request in order to finish in-flight request",
-                    self.registry
-                );
-                self.next = Some(new);
-            }
-            false => self.current = Some(new),
-        }
-
-        Ok(RequestFuture { conn: self })
-    }
-
-    /// Closes the socket and shuts down the connection
-    pub(crate) async fn shutdown(&mut self) -> Result<(), Error> {
-        info!("{}: Closing connection", self.registry);
-        timeout(self.timeout, self.stream.shutdown()).await?;
-        Ok(())
-    }
-
-    fn handle(
-        &mut self,
-        mut state: RequestState,
-        cx: &mut Context<'_>,
-    ) -> Result<Transition, Error> {
-        match &mut state {
-            RequestState::Writing { mut start, buf } => {
-                let wrote = match Pin::new(&mut self.stream).poll_write(cx, &buf[start..]) {
-                    Poll::Ready(Ok(wrote)) => wrote,
-                    Poll::Ready(Err(err)) => return Err(err.into()),
-                    Poll::Pending => return Ok(Transition::Pending(state)),
-                };
-
-                if wrote == 0 {
-                    return Err(io::Error::new(
-                        io::ErrorKind::UnexpectedEof,
-                        format!("{}: Unexpected EOF while writing", self.registry),
-                    )
-                    .into());
-                }
-
-                start += wrote;
-                debug!(
-                    "{}: Wrote {} bytes, {} out of {} done",
-                    self.registry,
-                    wrote,
-                    start,
-                    buf.len()
-                );
-
-                // Transition to reading the response's frame header once
-                // we've written the entire request
-                if start < buf.len() {
-                    return Ok(Transition::Next(state));
-                }
-
-                Ok(Transition::Next(RequestState::ReadLength {
-                    read: 0,
-                    buf: vec![0; 256],
-                }))
-            }
-            RequestState::ReadLength { mut read, buf } => {
-                let mut read_buf = ReadBuf::new(&mut buf[read..]);
-                match Pin::new(&mut self.stream).poll_read(cx, &mut read_buf) {
-                    Poll::Ready(Ok(())) => {}
-                    Poll::Ready(Err(err)) => return Err(err.into()),
-                    Poll::Pending => return Ok(Transition::Pending(state)),
-                };
-
-                let filled = read_buf.filled();
-                if filled.is_empty() {
-                    return Err(io::Error::new(
-                        io::ErrorKind::UnexpectedEof,
-                        format!("{}: Unexpected EOF while reading length", self.registry),
-                    )
-                    .into());
-                }
-
-                // We're looking for the frame header which tells us how long the response will be.
-                // The frame header is a 32-bit (4-byte) big-endian unsigned integer. If we don't
-                // have 4 bytes yet, stay in the `ReadLength` state, otherwise we transition to `Reading`.
-
-                read += filled.len();
-                if read < 4 {
-                    return Ok(Transition::Next(state));
-                }
-
-                let expected = u32::from_be_bytes(filled[..4].try_into()?) as usize;
-                debug!("{}: Expected response length: {}", self.registry, expected);
-                buf.resize(expected, 0);
-                Ok(Transition::Next(RequestState::Reading {
-                    read,
-                    buf: mem::take(buf),
-                    expected,
-                }))
-            }
-            RequestState::Reading {
-                mut read,
-                buf,
-                expected,
-            } => {
-                let mut read_buf = ReadBuf::new(&mut buf[read..]);
-                match Pin::new(&mut self.stream).poll_read(cx, &mut read_buf) {
-                    Poll::Ready(Ok(())) => {}
-                    Poll::Ready(Err(err)) => return Err(err.into()),
-                    Poll::Pending => return Ok(Transition::Pending(state)),
-                }
-
-                let filled = read_buf.filled();
-                if filled.is_empty() {
-                    return Err(io::Error::new(
-                        io::ErrorKind::UnexpectedEof,
-                        format!("{}: Unexpected EOF while reading", self.registry),
-                    )
-                    .into());
-                }
-
-                read += filled.len();
-                debug!(
-                    "{}: Read {} bytes, {} out of {} done",
-                    self.registry,
-                    filled.len(),
-                    read,
-                    expected
-                );
-
-                //
-
-                Ok(if read < *expected {
-                    // If we haven't received the entire response yet, stick to the `Reading` state.
-                    Transition::Next(state)
-                } else if let Some(next) = self.next.take() {
-                    // Otherwise, if we were just pushing through this request because it was already
-                    // in flight when we started a new one, ignore this response and move to the
-                    // next request (the one this `RequestFuture` is actually for).
-                    Transition::Next(next)
-                } else {
-                    // Otherwise, drain off the frame header and convert the rest to a `String`.
-                    buf.drain(..4);
-                    Transition::Done(String::from_utf8(mem::take(buf))?)
-                })
-            }
-        }
-    }
-}
-
-pub(crate) struct RequestFuture<'a, C: Connector> {
-    conn: &'a mut EppConnection<C>,
-}
-
-impl<'a, C: Connector> Future for RequestFuture<'a, C> {
-    type Output = Result<String, Error>;
-
-    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
-        let this = self.get_mut();
-        loop {
-            let state = this.conn.current.take().unwrap();
-            match this.conn.handle(state, cx) {
-                Ok(Transition::Next(next)) => {
-                    this.conn.current = Some(next);
-                    continue;
-                }
-                Ok(Transition::Pending(state)) => {
-                    this.conn.current = Some(state);
-                    return Poll::Pending;
-                }
-                Ok(Transition::Done(rsp)) => return Poll::Ready(Ok(rsp)),
-                Err(err) => {
-                    // Assume the error means the connection can no longer be used
-                    this.conn.next = None;
-                    return Poll::Ready(Err(err));
-                }
-            }
-        }
-    }
-}
-
-// Transitions between `RequestState`s
-enum Transition {
-    Pending(RequestState),
-    Next(RequestState),
-    Done(String),
-}
-
-#[derive(Debug)]
-enum RequestState {
-    // Writing the request command out to the peer
-    Writing {
-        // The amount of bytes we've already written
-        start: usize,
-        // The full XML request
-        buf: Vec<u8>,
-    },
-    // Reading the frame header (32-bit big-endian unsigned integer)
-    ReadLength {
-        // The amount of bytes we've already read
-        read: usize,
-        // The buffer we're using to read into
-        buf: Vec<u8>,
-    },
-    // Reading the entire frame
-    Reading {
-        // The amount of bytes we've already read
-        read: usize,
-        // The buffer we're using to read into
-        //
-        // This will still have the frame header in it, needs to be cut off before
-        // yielding the response to the caller.
-        buf: Vec<u8>,
-        // The expected length of the response according to the frame header
-        expected: usize,
-    },
-}
-
-impl RequestState {
-    fn new(command: &str) -> Result<Self, Error> {
-        let len = command.len();
+    /// Constructs an EPP XML request in the required form and sends it to the server
+    async fn send_epp_request(&mut self, content: &str) -> Result<(), Error> {
+        let len = content.len();
 
         let buf_size = len + 4;
         let mut buf: Vec<u8> = vec![0u8; buf_size];
@@ -303,8 +52,80 @@ impl RequestState {
         let len_u32: [u8; 4] = u32::to_be_bytes(len.try_into()?);
 
         buf[..4].clone_from_slice(&len_u32);
-        buf[4..].clone_from_slice(command.as_bytes());
-        Ok(Self::Writing { start: 0, buf })
+        buf[4..].clone_from_slice(content.as_bytes());
+
+        let wrote = timeout(self.timeout, self.stream.write(&buf)).await?;
+        debug!("{}: Wrote {} bytes", self.registry, wrote);
+        Ok(())
+    }
+
+    /// Receives response from the socket and converts it into an EPP XML string
+    async fn get_epp_response(&mut self) -> Result<String, Error> {
+        let mut buf = [0u8; 4];
+        timeout(self.timeout, self.stream.read_exact(&mut buf)).await?;
+
+        let buf_size: usize = u32::from_be_bytes(buf).try_into()?;
+
+        let message_size = buf_size - 4;
+        debug!("{}: Response buffer size: {}", self.registry, message_size);
+
+        let mut buf = vec![0; message_size];
+        let mut read_size: usize = 0;
+
+        loop {
+            let read = timeout(self.timeout, self.stream.read(&mut buf[read_size..])).await?;
+            debug!("{}: Read: {} bytes", self.registry, read);
+
+            read_size += read;
+            debug!("{}: Total read: {} bytes", self.registry, read_size);
+
+            if read == 0 {
+                return Err(io::Error::new(
+                    io::ErrorKind::UnexpectedEof,
+                    format!("{}: unexpected eof", self.registry),
+                )
+                .into());
+            } else if read_size >= message_size {
+                break;
+            }
+        }
+
+        self.ready = true;
+        Ok(String::from_utf8(buf)?)
+    }
+
+    pub(crate) async fn reconnect(&mut self) -> Result<(), Error> {
+        debug!("{}: reconnecting", self.registry);
+        self.ready = false;
+        self.stream = self.connector.connect(self.timeout).await?;
+        self.greeting = self.get_epp_response().await?;
+        self.ready = true;
+        Ok(())
+    }
+
+    /// Sends an EPP XML request to the registry and return the response
+    /// receieved to the request
+    pub(crate) async fn transact(&mut self, content: &str) -> Result<String, Error> {
+        if !self.ready {
+            debug!("{}: connection not ready", self.registry);
+            self.reconnect().await?;
+        }
+
+        debug!("{}: request: {}", self.registry, content);
+        self.send_epp_request(content).await?;
+
+        let response = self.get_epp_response().await?;
+        debug!("{}: response: {}", self.registry, response);
+
+        Ok(response)
+    }
+
+    /// Closes the socket and shuts the connection
+    pub(crate) async fn shutdown(&mut self) -> Result<(), Error> {
+        info!("{}: Closing connection", self.registry);
+        self.ready = false;
+        timeout(self.timeout, self.stream.shutdown()).await?;
+        Ok(())
     }
 }
 

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -17,8 +17,7 @@ pub(crate) struct EppConnection<C: Connector> {
     stream: C::Connection,
     pub greeting: String,
     timeout: Duration,
-    // Whether the connection is in a good state to start sending a request
-    ready: bool,
+    state: ConnectionState,
 }
 
 impl<C: Connector> EppConnection<C> {
@@ -33,16 +32,16 @@ impl<C: Connector> EppConnection<C> {
             connector,
             greeting: String::new(),
             timeout,
-            ready: false,
+            state: Default::default(),
         };
 
-        this.greeting = this.get_epp_response().await?;
-        this.ready = true;
+        this.greeting = this.read_epp_response().await?;
+        this.state = ConnectionState::Open;
         Ok(this)
     }
 
     /// Constructs an EPP XML request in the required form and sends it to the server
-    async fn send_epp_request(&mut self, content: &str) -> Result<(), Error> {
+    async fn write_epp_request(&mut self, content: &str) -> Result<(), Error> {
         let len = content.len();
 
         let buf_size = len + 4;
@@ -55,31 +54,35 @@ impl<C: Connector> EppConnection<C> {
         buf[4..].clone_from_slice(content.as_bytes());
 
         let wrote = timeout(self.timeout, self.stream.write(&buf)).await?;
-        debug!("{}: Wrote {} bytes", self.registry, wrote);
+        debug!(registry = self.registry, "Wrote {} bytes", wrote);
         Ok(())
     }
 
     /// Receives response from the socket and converts it into an EPP XML string
-    async fn get_epp_response(&mut self) -> Result<String, Error> {
+    async fn read_epp_response(&mut self) -> Result<String, Error> {
         let mut buf = [0u8; 4];
         timeout(self.timeout, self.stream.read_exact(&mut buf)).await?;
 
         let buf_size: usize = u32::from_be_bytes(buf).try_into()?;
 
         let message_size = buf_size - 4;
-        debug!("{}: Response buffer size: {}", self.registry, message_size);
+        debug!(
+            registry = self.registry,
+            "Response buffer size: {}", message_size
+        );
 
         let mut buf = vec![0; message_size];
         let mut read_size: usize = 0;
 
         loop {
             let read = timeout(self.timeout, self.stream.read(&mut buf[read_size..])).await?;
-            debug!("{}: Read: {} bytes", self.registry, read);
+            debug!(registry = self.registry, "Read: {} bytes", read);
 
             read_size += read;
-            debug!("{}: Total read: {} bytes", self.registry, read_size);
+            debug!(registry = self.registry, "Total read: {} bytes", read_size);
 
             if read == 0 {
+                self.state = ConnectionState::Closed;
                 return Err(io::Error::new(
                     io::ErrorKind::UnexpectedEof,
                     format!("{}: unexpected eof", self.registry),
@@ -90,41 +93,41 @@ impl<C: Connector> EppConnection<C> {
             }
         }
 
-        self.ready = true;
         Ok(String::from_utf8(buf)?)
     }
 
     pub(crate) async fn reconnect(&mut self) -> Result<(), Error> {
-        debug!("{}: reconnecting", self.registry);
-        self.ready = false;
+        debug!(registry = self.registry, "reconnecting");
+        self.state = ConnectionState::Opening;
         self.stream = self.connector.connect(self.timeout).await?;
-        self.greeting = self.get_epp_response().await?;
-        self.ready = true;
+        self.greeting = self.read_epp_response().await?;
+        self.state = ConnectionState::Open;
         Ok(())
     }
 
     /// Sends an EPP XML request to the registry and return the response
     /// receieved to the request
     pub(crate) async fn transact(&mut self, content: &str) -> Result<String, Error> {
-        if !self.ready {
-            debug!("{}: connection not ready", self.registry);
+        if self.state != ConnectionState::Open {
+            debug!(registry = self.registry, " connection not ready");
             self.reconnect().await?;
         }
 
-        debug!("{}: request: {}", self.registry, content);
-        self.send_epp_request(content).await?;
+        debug!(registry = self.registry, " request: {}", content);
+        self.write_epp_request(content).await?;
 
-        let response = self.get_epp_response().await?;
-        debug!("{}: response: {}", self.registry, response);
+        let response = self.read_epp_response().await?;
+        debug!(registry = self.registry, " response: {}", response);
 
         Ok(response)
     }
 
     /// Closes the socket and shuts the connection
     pub(crate) async fn shutdown(&mut self) -> Result<(), Error> {
-        info!("{}: Closing connection", self.registry);
-        self.ready = false;
+        info!(registry = self.registry, "Closing connection");
+        self.state = ConnectionState::Closing;
         timeout(self.timeout, self.stream.shutdown()).await?;
+        self.state = ConnectionState::Closed;
         Ok(())
     }
 }
@@ -138,4 +141,13 @@ pub(crate) async fn timeout<T, E: Into<Error>>(
         Ok(Err(e)) => Err(e.into()),
         Err(_) => Err(Error::Timeout),
     }
+}
+
+#[derive(Debug, Default, PartialEq, Eq)]
+enum ConnectionState {
+    #[default]
+    Opening,
+    Open,
+    Closing,
+    Closed,
 }

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -4,10 +4,10 @@ use std::future::Future;
 use std::time::Duration;
 use std::{io, str, u32};
 
-use async_trait::async_trait;
-use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tracing::{debug, info};
 
+use crate::connect::Connector;
 use crate::error::Error;
 
 /// EPP Connection struct with some metadata for the connection
@@ -138,11 +138,4 @@ pub(crate) async fn timeout<T, E: Into<Error>>(
         Ok(Err(e)) => Err(e.into()),
         Err(_) => Err(Error::Timeout),
     }
-}
-
-#[async_trait]
-pub trait Connector {
-    type Connection: AsyncRead + AsyncWrite + Unpin;
-
-    async fn connect(&self, timeout: Duration) -> Result<Self::Connection, Error>;
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,6 +1,5 @@
 //! Error types to wrap internal errors and make EPP errors easier to read
 
-use std::array::TryFromSliceError;
 use std::error::Error as StdError;
 use std::fmt::{self, Display};
 use std::io;
@@ -68,12 +67,6 @@ impl From<FromUtf8Error> for Error {
 
 impl From<Utf8Error> for Error {
     fn from(e: Utf8Error) -> Self {
-        Self::Other(e.into())
-    }
-}
-
-impl From<TryFromSliceError> for Error {
-    fn from(e: TryFromSliceError) -> Self {
         Self::Other(e.into())
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -12,8 +12,10 @@ use crate::response::ResponseStatus;
 /// Error enum holding the possible error types
 #[derive(Debug)]
 pub enum Error {
+    Closed,
     Command(Box<ResponseStatus>),
     Io(std::io::Error),
+    Reconnect,
     Timeout,
     Xml(Box<dyn StdError + Send + Sync>),
     Other(Box<dyn StdError + Send + Sync>),
@@ -24,10 +26,12 @@ impl StdError for Error {}
 impl Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
+            Error::Closed => write!(f, "closed"),
             Error::Command(e) => {
                 write!(f, "command error: {}", e.result.message)
             }
             Error::Io(e) => write!(f, "I/O error: {}", e),
+            Error::Reconnect => write!(f, "failed to reconnect"),
             Error::Timeout => write!(f, "timeout"),
             Error::Xml(e) => write!(f, "(de)serialization error: {}", e),
             Error::Other(e) => write!(f, "error: {}", e),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -59,7 +59,7 @@
 //! use std::net::ToSocketAddrs;
 //! use std::time::Duration;
 //!
-//! use epp_client::connect::connect;
+//! use epp_client::connect::{connect, DEFAULT_IDLE_TIMEOUT};
 //! use epp_client::domain::DomainCheck;
 //! use epp_client::login::Login;
 //!
@@ -67,7 +67,7 @@
 //! async fn main() {
 //!     // Create an instance of EppClient
 //!     let timeout = Duration::from_secs(5);
-//!     let (mut client, mut connection) = match connect("registry_name".into(), ("example.com".into(), 7000), None, timeout).await {
+//!     let (mut client, mut connection) = match connect("registry_name".into(), ("example.com".into(), 7000), None, timeout, Some(DEFAULT_IDLE_TIMEOUT)).await {
 //!         Ok(c) => c,
 //!         Err(e) => panic!("Failed to create EppClient: {}",  e)
 //!     };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -94,6 +94,7 @@
 
 pub mod client;
 pub mod common;
+pub mod connect;
 pub mod connection;
 pub mod contact;
 pub mod domain;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -59,7 +59,7 @@
 //! use std::net::ToSocketAddrs;
 //! use std::time::Duration;
 //!
-//! use epp_client::EppClient;
+//! use epp_client::connect::connect;
 //! use epp_client::domain::DomainCheck;
 //! use epp_client::login::Login;
 //!
@@ -67,10 +67,14 @@
 //! async fn main() {
 //!     // Create an instance of EppClient
 //!     let timeout = Duration::from_secs(5);
-//!     let mut client = match EppClient::connect("registry_name".to_string(), ("example.com".to_owned(), 7000), None, timeout).await {
-//!         Ok(client) => client,
+//!     let (mut client, mut connection) = match connect("registry_name".into(), ("example.com".into(), 7000), None, timeout).await {
+//!         Ok(c) => c,
 //!         Err(e) => panic!("Failed to create EppClient: {}",  e)
 //!     };
+//!
+//!     tokio::spawn(async move {
+//!         connection.run().await.unwrap();
+//!     });
 //!
 //!     let login = Login::new("username", "password", None, None);
 //!     client.transact(&login, "transaction-id").await.unwrap();

--- a/tests/basic.rs
+++ b/tests/basic.rs
@@ -104,7 +104,7 @@ async fn client() {
         .unwrap();
 
     assert_eq!(client.xml_greeting(), xml("response/greeting.xml"));
-    let rsp = client
+    client
         .transact(
             &Login::new(
                 "username",
@@ -116,8 +116,6 @@ async fn client() {
         )
         .await
         .unwrap();
-
-    assert_eq!(rsp.result.code, ResultCode::CommandCompletedSuccessfully);
 
     let rsp = client
         .transact(

--- a/tests/basic.rs
+++ b/tests/basic.rs
@@ -104,7 +104,7 @@ async fn client() {
         .unwrap();
 
     assert_eq!(client.xml_greeting(), xml("response/greeting.xml"));
-    client
+    let rsp = client
         .transact(
             &Login::new(
                 "username",
@@ -116,6 +116,8 @@ async fn client() {
         )
         .await
         .unwrap();
+
+    assert_eq!(rsp.result.code, ResultCode::CommandCompletedSuccessfully);
 
     let rsp = client
         .transact(

--- a/tests/basic.rs
+++ b/tests/basic.rs
@@ -4,6 +4,7 @@ use std::str;
 use std::time::Duration;
 
 use async_trait::async_trait;
+use epp_client::connect::connect_with_connector;
 use regex::Regex;
 use tokio::time::timeout;
 use tokio_test::io::Builder;
@@ -11,7 +12,6 @@ use tokio_test::io::Builder;
 use epp_client::domain::{DomainCheck, DomainContact, DomainCreate, Period};
 use epp_client::login::Login;
 use epp_client::response::ResultCode;
-use epp_client::EppClient;
 
 const CLTRID: &str = "cltrid:1626454866";
 
@@ -99,7 +99,7 @@ async fn client() {
         }
     }
 
-    let mut client = EppClient::new(FakeConnector, "test".into(), Duration::from_secs(5))
+    let mut client = connect_with_connector(FakeConnector, "test".into(), Duration::from_secs(5))
         .await
         .unwrap();
 
@@ -173,7 +173,7 @@ async fn dropped() {
         }
     }
 
-    let mut client = EppClient::new(FakeConnector, "test".into(), Duration::from_secs(5))
+    let mut client = connect_with_connector(FakeConnector, "test".into(), Duration::from_secs(5))
         .await
         .unwrap();
 


### PR DESCRIPTION
This changes the fundamental design of the crate.
Currently:
The EppConnection (holding the underlying TCP stream) returns a Future referencing the EppConnection on requests. The future then resolves using the internal StateMachine of epp-client.

Now:
Other client crates that hold stateful TCP streams are structured in two halves. A client and a connection. The connection is an i/o task holding the TCP stream, and the client is talking to the connection task via mpsc channels. A request made by the client creates another channel of size one, to receive the response from the connection once the response is completely read from the TCP stream.

This is now applied to epp-client as well. This tries to reuse most of the state machine currently implemented.

Todo:
- [x] PR Cleanup
- [x] More tests
- [x] Add keep alive logic