### PR TITLE
feat: expose `Period::new` by introducing a `PeriodUnit` enum

### DIFF
--- a/src/domain/create.rs
+++ b/src/domain/create.rs
@@ -90,7 +90,7 @@ mod tests {
     use chrono::{TimeZone, Utc};
 
     use super::{DomainContact, DomainCreate, Period};
-    use crate::domain::{HostAttr, HostInfo, HostObj};
+    use crate::domain::{HostAttr, HostInfo, HostObj, PeriodLength};
     use crate::response::ResultCode;
     use crate::tests::{assert_serialized, response_from_file, CLTRID, SUCCESS_MSG, SVTRID};
 
@@ -113,7 +113,7 @@ mod tests {
 
         let object = DomainCreate::new(
             "eppdev-1.com",
-            Period::years(1).unwrap(),
+            Period::Years(PeriodLength::new(1).unwrap()),
             None,
             Some("eppdev-contact-3"),
             "epP4uthd#v",
@@ -150,7 +150,7 @@ mod tests {
         ];
         let object = DomainCreate::new(
             "eppdev-1.com",
-            Period::years(1).unwrap(),
+            Period::Years(PeriodLength::new(1).unwrap()),
             Some(hosts),
             Some("eppdev-contact-3"),
             "epP4uthd#v",
@@ -193,7 +193,7 @@ mod tests {
 
         let object = DomainCreate::new(
             "eppdev-2.com",
-            Period::years(1).unwrap(),
+            Period::Years(PeriodLength::new(1).unwrap()),
             Some(hosts),
             Some("eppdev-contact-3"),
             "epP4uthd#v",

--- a/src/domain/mod.rs
+++ b/src/domain/mod.rs
@@ -170,16 +170,6 @@ impl PeriodLength {
     }
 }
 
-impl Period {
-    pub fn years(length: u8) -> Result<Self, Error> {
-        PeriodLength::new(length).map(Self::Years)
-    }
-
-    pub fn months(length: u8) -> Result<Self, Error> {
-        PeriodLength::new(length).map(Self::Months)
-    }
-}
-
 impl ToXml for Period {
     fn serialize<W: fmt::Write + ?Sized>(
         &self,

--- a/src/domain/mod.rs
+++ b/src/domain/mod.rs
@@ -164,7 +164,7 @@ impl PeriodLength {
         match length {
             1..=99 => Ok(Self(length)),
             0 | 100.. => Err(Error::Other(
-                "Period length must be greater than 0 and less than 100".into(),
+                "period length must be greater than 0 and less than 100".into(),
             )),
         }
     }

--- a/src/domain/renew.rs
+++ b/src/domain/renew.rs
@@ -66,6 +66,7 @@ pub struct RenewData {
 #[cfg(test)]
 mod tests {
     use super::{DomainRenew, Period};
+    use crate::domain::PeriodLength;
     use crate::response::ResultCode;
     use crate::tests::{assert_serialized, response_from_file, CLTRID, SUCCESS_MSG, SVTRID};
 
@@ -74,7 +75,11 @@ mod tests {
     #[test]
     fn command() {
         let exp_date = NaiveDate::from_ymd_opt(2022, 7, 23).unwrap();
-        let object = DomainRenew::new("eppdev.com", exp_date, Period::years(1).unwrap());
+        let object = DomainRenew::new(
+            "eppdev.com",
+            exp_date,
+            Period::Years(PeriodLength::new(1).unwrap()),
+        );
         assert_serialized("request/domain/renew.xml", &object);
     }
 

--- a/src/domain/transfer.rs
+++ b/src/domain/transfer.rs
@@ -124,13 +124,17 @@ mod tests {
     use chrono::{TimeZone, Utc};
 
     use super::{DomainTransfer, Period};
+    use crate::domain::PeriodLength;
     use crate::response::ResultCode;
     use crate::tests::{assert_serialized, response_from_file, CLTRID, SUCCESS_MSG, SVTRID};
 
     #[test]
     fn request_command() {
-        let object =
-            DomainTransfer::new("testing.com", Some(Period::years(1).unwrap()), "epP4uthd#v");
+        let object = DomainTransfer::new(
+            "testing.com",
+            Some(Period::Years(PeriodLength::new(1).unwrap())),
+            "epP4uthd#v",
+        );
         assert_serialized("request/domain/transfer_request.xml", &object);
     }
 

--- a/src/extensions/secdns.rs
+++ b/src/extensions/secdns.rs
@@ -371,7 +371,7 @@ impl ToXml for Protocol {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::domain;
+    use crate::domain::{self, Period, PeriodLength};
     use crate::tests::assert_serialized;
 
     #[test]
@@ -404,7 +404,7 @@ mod tests {
         ];
         let object = domain::DomainCreate::new(
             "example.com",
-            domain::Period::years(2).unwrap(),
+            Period::Years(PeriodLength::new(2).unwrap()),
             Some(&ns),
             Some("jd1234"),
             "2fooBAR",
@@ -452,7 +452,7 @@ mod tests {
         ];
         let object = domain::DomainCreate::new(
             "example.com",
-            domain::Period::years(2).unwrap(),
+            Period::Years(PeriodLength::new(2).unwrap()),
             Some(&ns),
             Some("jd1234"),
             "2fooBAR",
@@ -493,7 +493,7 @@ mod tests {
         ];
         let object = domain::DomainCreate::new(
             "example.com",
-            domain::Period::years(2).unwrap(),
+            Period::Years(PeriodLength::new(2).unwrap()),
             Some(&ns),
             Some("jd1234"),
             "2fooBAR",

--- a/tests/basic.rs
+++ b/tests/basic.rs
@@ -9,7 +9,7 @@ use tokio::time::timeout;
 use tokio_test::io::Builder;
 
 use instant_epp::client::{Connector, EppClient};
-use instant_epp::domain::{DomainCheck, DomainContact, DomainCreate, Period};
+use instant_epp::domain::{DomainCheck, DomainContact, DomainCreate, Period, PeriodLength};
 use instant_epp::login::Login;
 use instant_epp::response::ResultCode;
 use instant_epp::Error;
@@ -232,7 +232,7 @@ async fn dropped() {
     // remainder of the in-flight request before starting the new one, and succeed.
     let create = DomainCreate::new(
         "eppdev-1.com",
-        Period::years(1).unwrap(),
+        Period::Years(PeriodLength::new(1).unwrap()),
         None,
         Some("eppdev-contact-3"),
         "epP4uthd#v",


### PR DESCRIPTION
The `Perdiod::years` and `Period::months` may feel redundant now, but keeping them to not break any public API.

We're building an interface at work. Doing this change upstream removes the need for us (and probably others) to create a data type that solely acts as a bridge.