### PR TITLE
chore: elide lifetimes where possible

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -196,14 +196,14 @@ impl<'c, 'e, C: Command, E: Extension> From<(&'c C, &'e E)> for RequestData<'c, 
 }
 
 // Manual impl because this does not depend on whether `C` and `E` are `Clone`
-impl<'c, 'e, C, E> Clone for RequestData<'c, 'e, C, E> {
+impl<C, E> Clone for RequestData<'_, '_, C, E> {
     fn clone(&self) -> Self {
         *self
     }
 }
 
 // Manual impl because this does not depend on whether `C` and `E` are `Copy`
-impl<'c, 'e, C, E> Copy for RequestData<'c, 'e, C, E> {}
+impl<C, E> Copy for RequestData<'_, '_, C, E> {}
 
 #[cfg(feature = "rustls")]
 pub use rustls_connector::RustlsConnector;

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -230,7 +230,7 @@ pub(crate) struct RequestFuture<'a, C: Connector> {
     conn: &'a mut EppConnection<C>,
 }
 
-impl<'a, C: Connector> Future for RequestFuture<'a, C> {
+impl<C: Connector> Future for RequestFuture<'_, C> {
     type Output = Result<String, Error>;
 
     fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {

--- a/src/contact/check.rs
+++ b/src/contact/check.rs
@@ -8,9 +8,9 @@ use super::XMLNS;
 use crate::common::{NoExtension, EPP_XMLNS};
 use crate::request::{Command, Transaction};
 
-impl<'a> Transaction<NoExtension> for ContactCheck<'a> {}
+impl Transaction<NoExtension> for ContactCheck<'_> {}
 
-impl<'a> Command for ContactCheck<'a> {
+impl Command for ContactCheck<'_> {
     type Response = CheckData;
     const COMMAND: &'static str = "check";
 }

--- a/src/contact/create.rs
+++ b/src/contact/create.rs
@@ -7,9 +7,9 @@ use super::{ContactAuthInfo, Fax, PostalInfo, Voice, XMLNS};
 use crate::common::{NoExtension, EPP_XMLNS};
 use crate::request::{Command, Transaction};
 
-impl<'a> Transaction<NoExtension> for ContactCreate<'a> {}
+impl Transaction<NoExtension> for ContactCreate<'_> {}
 
-impl<'a> Command for ContactCreate<'a> {
+impl Command for ContactCreate<'_> {
     type Response = CreateData;
     const COMMAND: &'static str = "create";
 }

--- a/src/contact/delete.rs
+++ b/src/contact/delete.rs
@@ -6,9 +6,9 @@ use super::XMLNS;
 use crate::common::{NoExtension, EPP_XMLNS};
 use crate::request::{Command, Transaction};
 
-impl<'a> Transaction<NoExtension> for ContactDelete<'a> {}
+impl Transaction<NoExtension> for ContactDelete<'_> {}
 
-impl<'a> Command for ContactDelete<'a> {
+impl Command for ContactDelete<'_> {
     type Response = ();
     const COMMAND: &'static str = "delete";
 }

--- a/src/contact/info.rs
+++ b/src/contact/info.rs
@@ -7,9 +7,9 @@ use super::{ContactAuthInfo, Fax, PostalInfo, Status, Voice, XMLNS};
 use crate::common::{NoExtension, EPP_XMLNS};
 use crate::request::{Command, Transaction};
 
-impl<'a> Transaction<NoExtension> for ContactInfo<'a> {}
+impl Transaction<NoExtension> for ContactInfo<'_> {}
 
-impl<'a> Command for ContactInfo<'a> {
+impl Command for ContactInfo<'_> {
     type Response = InfoData;
     const COMMAND: &'static str = "info";
 }

--- a/src/contact/update.rs
+++ b/src/contact/update.rs
@@ -6,9 +6,9 @@ use super::{ContactAuthInfo, Fax, PostalInfo, Status, Voice, XMLNS};
 use crate::common::{NoExtension, EPP_XMLNS};
 use crate::request::{Command, Transaction};
 
-impl<'a> Transaction<NoExtension> for ContactUpdate<'a> {}
+impl Transaction<NoExtension> for ContactUpdate<'_> {}
 
-impl<'a> Command for ContactUpdate<'a> {
+impl Command for ContactUpdate<'_> {
     type Response = ();
     const COMMAND: &'static str = "update";
 }

--- a/src/domain/check.rs
+++ b/src/domain/check.rs
@@ -8,9 +8,9 @@ use super::XMLNS;
 use crate::common::{NoExtension, EPP_XMLNS};
 use crate::request::{Command, Transaction};
 
-impl<'a> Transaction<NoExtension> for DomainCheck<'a> {}
+impl Transaction<NoExtension> for DomainCheck<'_> {}
 
-impl<'a> Command for DomainCheck<'a> {
+impl Command for DomainCheck<'_> {
     type Response = CheckData;
     const COMMAND: &'static str = "check";
 }

--- a/src/domain/create.rs
+++ b/src/domain/create.rs
@@ -7,9 +7,9 @@ use super::{DomainAuthInfo, DomainContact, HostInfo, NameServers, Period, XMLNS}
 use crate::common::{NoExtension, EPP_XMLNS};
 use crate::request::{Command, Transaction};
 
-impl<'a> Transaction<NoExtension> for DomainCreate<'a> {}
+impl Transaction<NoExtension> for DomainCreate<'_> {}
 
-impl<'a> Command for DomainCreate<'a> {
+impl Command for DomainCreate<'_> {
     type Response = CreateData;
     const COMMAND: &'static str = "create";
 }

--- a/src/domain/delete.rs
+++ b/src/domain/delete.rs
@@ -6,9 +6,9 @@ use super::XMLNS;
 use crate::common::{NoExtension, EPP_XMLNS};
 use crate::request::{Command, Transaction};
 
-impl<'a> Transaction<NoExtension> for DomainDelete<'a> {}
+impl Transaction<NoExtension> for DomainDelete<'_> {}
 
-impl<'a> Command for DomainDelete<'a> {
+impl Command for DomainDelete<'_> {
     type Response = ();
     const COMMAND: &'static str = "delete";
 }

--- a/src/domain/info.rs
+++ b/src/domain/info.rs
@@ -7,9 +7,9 @@ use super::{DomainAuthInfo, DomainContact, HostAttr, NameServers, Status, XMLNS}
 use crate::common::{NoExtension, EPP_XMLNS};
 use crate::request::{Command, Transaction};
 
-impl<'a> Transaction<NoExtension> for DomainInfo<'a> {}
+impl Transaction<NoExtension> for DomainInfo<'_> {}
 
-impl<'a> Command for DomainInfo<'a> {
+impl Command for DomainInfo<'_> {
     type Response = InfoData;
     const COMMAND: &'static str = "info";
 }

--- a/src/domain/renew.rs
+++ b/src/domain/renew.rs
@@ -7,9 +7,9 @@ use super::{Period, XMLNS};
 use crate::common::{NoExtension, EPP_XMLNS};
 use crate::request::{Command, Transaction};
 
-impl<'a> Transaction<NoExtension> for DomainRenew<'a> {}
+impl Transaction<NoExtension> for DomainRenew<'_> {}
 
-impl<'a> Command for DomainRenew<'a> {
+impl Command for DomainRenew<'_> {
     type Response = RenewData;
     const COMMAND: &'static str = "renew";
 }

--- a/src/domain/transfer.rs
+++ b/src/domain/transfer.rs
@@ -7,9 +7,9 @@ use super::{DomainAuthInfo, Period, XMLNS};
 use crate::common::{NoExtension, EPP_XMLNS};
 use crate::request::{Command, Transaction};
 
-impl<'a> Transaction<NoExtension> for DomainTransfer<'a> {}
+impl Transaction<NoExtension> for DomainTransfer<'_> {}
 
-impl<'a> Command for DomainTransfer<'a> {
+impl Command for DomainTransfer<'_> {
     type Response = TransferData;
     const COMMAND: &'static str = "transfer";
 }

--- a/src/domain/update.rs
+++ b/src/domain/update.rs
@@ -8,9 +8,9 @@ use crate::{
     request::{Command, Transaction},
 };
 
-impl<'a> Transaction<NoExtension> for DomainUpdate<'a> {}
+impl Transaction<NoExtension> for DomainUpdate<'_> {}
 
-impl<'a> Command for DomainUpdate<'a> {
+impl Command for DomainUpdate<'_> {
     type Response = ();
     const COMMAND: &'static str = "update";
 }

--- a/src/extensions/frnic/contact.rs
+++ b/src/extensions/frnic/contact.rs
@@ -8,7 +8,7 @@ use super::{Create, Ext, XMLNS};
 
 impl<'a> Transaction<Ext<Create<ContactCreate<'a>>>> for crate::contact::create::ContactCreate<'a> {}
 
-impl<'a> Extension for Ext<Create<ContactCreate<'a>>> {
+impl Extension for Ext<Create<ContactCreate<'_>>> {
     type Response = ();
 }
 
@@ -81,7 +81,7 @@ impl<'a> ContactCreate<'a> {
     }
 }
 
-impl<'a> ToXml for ContactCreate<'a> {
+impl ToXml for ContactCreate<'_> {
     fn serialize<W: core::fmt::Write + ?Sized>(
         &self,
         _: Option<Id<'_>>,
@@ -124,7 +124,7 @@ pub enum LegalStatus<'a> {
     Other(Cow<'a, str>),
 }
 
-impl<'a> ToXml for LegalStatus<'a> {
+impl ToXml for LegalStatus<'_> {
     fn serialize<W: core::fmt::Write + ?Sized>(
         &self,
         _field: Option<Id<'_>>,

--- a/src/extensions/namestore.rs
+++ b/src/extensions/namestore.rs
@@ -59,7 +59,7 @@ impl<'a> NameStore<'a> {
     }
 }
 
-impl<'a> Extension for NameStore<'a> {
+impl Extension for NameStore<'_> {
     type Response = NameStore<'static>;
 }
 

--- a/src/extensions/rgp/report.rs
+++ b/src/extensions/rgp/report.rs
@@ -37,7 +37,7 @@ impl<'a> RgpRestoreReport<'a> {
     }
 }
 
-impl<'a> Extension for Update<RgpRestoreReport<'a>> {
+impl Extension for Update<RgpRestoreReport<'_>> {
     type Response = NoExtension;
 }
 

--- a/src/extensions/rgp/request.rs
+++ b/src/extensions/rgp/request.rs
@@ -13,7 +13,7 @@ impl<'a> Transaction<Update<RgpRestoreRequest<'a>>> for DomainUpdate<'a> {}
 
 impl<'a> Transaction<Update<RgpRestoreRequest<'a>>> for DomainInfo<'a> {}
 
-impl<'a> Extension for Update<RgpRestoreRequest<'a>> {
+impl Extension for Update<RgpRestoreRequest<'_>> {
     type Response = RgpRequestResponse;
 }
 

--- a/src/extensions/secdns.rs
+++ b/src/extensions/secdns.rs
@@ -13,7 +13,7 @@ pub const XMLNS: &str = "urn:ietf:params:xml:ns:secDNS-1.1";
 
 impl<'a> Transaction<CreateData<'a>> for crate::domain::create::DomainCreate<'a> {}
 
-impl<'a> Extension for CreateData<'a> {
+impl Extension for CreateData<'_> {
     type Response = NoExtension;
 }
 

--- a/src/host/check.rs
+++ b/src/host/check.rs
@@ -8,9 +8,9 @@ use super::XMLNS;
 use crate::common::{NoExtension, EPP_XMLNS};
 use crate::request::{Command, Transaction};
 
-impl<'a> Transaction<NoExtension> for HostCheck<'a> {}
+impl Transaction<NoExtension> for HostCheck<'_> {}
 
-impl<'a> Command for HostCheck<'a> {
+impl Command for HostCheck<'_> {
     type Response = CheckData;
     const COMMAND: &'static str = "check";
 }

--- a/src/host/create.rs
+++ b/src/host/create.rs
@@ -9,9 +9,9 @@ use super::{serialize_host_addrs_option, XMLNS};
 use crate::common::{NoExtension, EPP_XMLNS};
 use crate::request::{Command, Transaction};
 
-impl<'a> Transaction<NoExtension> for HostCreate<'a> {}
+impl Transaction<NoExtension> for HostCreate<'_> {}
 
-impl<'a> Command for HostCreate<'a> {
+impl Command for HostCreate<'_> {
     type Response = CreateData;
     const COMMAND: &'static str = "create";
 }

--- a/src/host/delete.rs
+++ b/src/host/delete.rs
@@ -6,9 +6,9 @@ use super::XMLNS;
 use crate::common::{NoExtension, EPP_XMLNS};
 use crate::request::{Command, Transaction};
 
-impl<'a> Transaction<NoExtension> for HostDelete<'a> {}
+impl Transaction<NoExtension> for HostDelete<'_> {}
 
-impl<'a> Command for HostDelete<'a> {
+impl Command for HostDelete<'_> {
     type Response = ();
     const COMMAND: &'static str = "delete";
 }

--- a/src/host/info.rs
+++ b/src/host/info.rs
@@ -10,9 +10,9 @@ use super::{HostAddr, Status, XMLNS};
 use crate::common::{NoExtension, EPP_XMLNS};
 use crate::request::{Command, Transaction};
 
-impl<'a> Transaction<NoExtension> for HostInfo<'a> {}
+impl Transaction<NoExtension> for HostInfo<'_> {}
 
-impl<'a> Command for HostInfo<'a> {
+impl Command for HostInfo<'_> {
     type Response = InfoData;
     const COMMAND: &'static str = "info";
 }

--- a/src/host/update.rs
+++ b/src/host/update.rs
@@ -8,9 +8,9 @@ use super::{serialize_host_addrs_option, Status, XMLNS};
 use crate::common::{NoExtension, EPP_XMLNS};
 use crate::request::{Command, Transaction};
 
-impl<'a> Transaction<NoExtension> for HostUpdate<'a> {}
+impl Transaction<NoExtension> for HostUpdate<'_> {}
 
-impl<'a> Command for HostUpdate<'a> {
+impl Command for HostUpdate<'_> {
     type Response = ();
     const COMMAND: &'static str = "update";
 }

--- a/src/login.rs
+++ b/src/login.rs
@@ -8,7 +8,7 @@ use crate::{
     request::{Command, Transaction, EPP_LANG, EPP_VERSION},
 };
 
-impl<'a> Transaction<NoExtension> for Login<'a> {}
+impl Transaction<NoExtension> for Login<'_> {}
 
 /// Type corresponding to the `<login>` tag in an EPP XML login request
 #[derive(Debug, Eq, PartialEq, ToXml)]
@@ -71,7 +71,7 @@ impl<'a> Login<'a> {
     }
 }
 
-impl<'a> Command for Login<'a> {
+impl Command for Login<'_> {
     type Response = ();
     const COMMAND: &'static str = "login";
 }

--- a/src/request.rs
+++ b/src/request.rs
@@ -44,7 +44,7 @@ impl<'a, E: Extension, D: Transaction<E>> CommandWrapper<'a, D, E> {
     }
 }
 
-impl<'a, D: ToXml, E: ToXml> ToXml for CommandWrapper<'a, D, E> {
+impl<D: ToXml, E: ToXml> ToXml for CommandWrapper<'_, D, E> {
     fn serialize<W: std::fmt::Write + ?Sized>(
         &self,
         _: Option<instant_xml::Id<'_>>,


### PR DESCRIPTION
Part of newer clippy lints. Fixed with `cargo clippy --fix`.