### PR TITLE
feat!: add `InfoType` enum for PostalInfo.info_type

### DIFF
--- a/src/contact/create.rs
+++ b/src/contact/create.rs
@@ -86,7 +86,7 @@ mod tests {
     use chrono::{TimeZone, Utc};
 
     use super::{ContactCreate, Fax, PostalInfo, Voice};
-    use crate::contact::Address;
+    use crate::contact::{Address, InfoType};
     use crate::response::ResultCode;
     use crate::tests::{assert_serialized, response_from_file, CLTRID, SUCCESS_MSG, SVTRID};
 
@@ -100,7 +100,12 @@ mod tests {
             Some("392374"),
             "FR".parse().unwrap(),
         );
-        let postal_info = PostalInfo::new("int", "John Doe", Some("Acme Widgets"), address);
+        let postal_info = PostalInfo::new(
+            InfoType::International,
+            "John Doe",
+            Some("Acme Widgets"),
+            address,
+        );
         let mut voice = Voice::new("+33.47237942");
         voice.set_extension("123");
         let mut fax = Fax::new("+33.86698799");
@@ -121,7 +126,7 @@ mod tests {
     #[test]
     fn command_minimal() {
         let address = Address::new(&[], "Paris", None, None, "FR".parse().unwrap());
-        let postal_info = PostalInfo::new("int", "John Doe", None, address);
+        let postal_info = PostalInfo::new(InfoType::International, "John Doe", None, address);
         let object = ContactCreate::new(
             "eppdev-contact-3",
             "contact@eppdev.net",

--- a/src/contact/info.rs
+++ b/src/contact/info.rs
@@ -93,7 +93,7 @@ mod tests {
     use chrono::{TimeZone, Utc};
 
     use super::ContactInfo;
-    use crate::contact::Status;
+    use crate::contact::{InfoType, Status};
     use crate::response::ResultCode;
     use crate::tests::{assert_serialized, response_from_file, CLTRID, SUCCESS_MSG, SVTRID};
 
@@ -118,7 +118,7 @@ mod tests {
         assert_eq!(result.id, "eppdev-contact-3");
         assert_eq!(result.roid, "UNDEF-ROID");
         assert_eq!(result.statuses[0], Status::Ok);
-        assert_eq!(result.postal_info.info_type, "loc");
+        assert_eq!(result.postal_info.info_type, InfoType::Local);
         assert_eq!(result.postal_info.name, "John Doe");
         assert_eq!(result.postal_info.organization, Some("Acme Widgets".into()));
         assert_eq!(result.postal_info.address.street[0], "58");
@@ -165,7 +165,7 @@ mod tests {
         assert_eq!(result.id, "eppdev-contact-3");
         assert_eq!(result.roid, "UNDEF-ROID");
         assert_eq!(result.statuses[0], Status::Ok);
-        assert_eq!(result.postal_info.info_type, "loc");
+        assert_eq!(result.postal_info.info_type, InfoType::Local);
         assert_eq!(result.postal_info.name, "John Doe");
         assert_eq!(result.postal_info.organization, None);
         assert_eq!(result.postal_info.address.street[0], "58");

--- a/src/contact/mod.rs
+++ b/src/contact/mod.rs
@@ -192,7 +192,7 @@ impl<'a> Address<'a> {
 pub struct PostalInfo<'a> {
     /// The 'type' attr on `<postalInfo>`
     #[xml(rename = "type", attribute)]
-    pub info_type: Cow<'a, str>,
+    pub info_type: InfoType,
     /// The `<name>` tag under `<postalInfo>`
     pub name: Cow<'a, str>,
     /// The `<org>` tag under `<postalInfo>`
@@ -205,18 +205,27 @@ pub struct PostalInfo<'a> {
 impl<'a> PostalInfo<'a> {
     /// Creates a new PostalInfo instance
     pub fn new(
-        info_type: &'a str,
+        info_type: InfoType,
         name: &'a str,
         organization: Option<&'a str>,
         address: Address<'a>,
     ) -> Self {
         Self {
-            info_type: info_type.into(),
+            info_type,
             name: name.into(),
             organization: organization.map(|org| org.into()),
             address,
         }
     }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, ToXml, FromXml)]
+#[xml(scalar)]
+pub enum InfoType {
+    #[xml(rename = "loc")]
+    Local,
+    #[xml(rename = "int")]
+    International,
 }
 
 /// The `<status>` type on contact transactions

--- a/src/contact/update.rs
+++ b/src/contact/update.rs
@@ -105,7 +105,7 @@ pub struct ContactUpdate<'a> {
 #[cfg(test)]
 mod tests {
     use super::{ContactUpdate, PostalInfo, Status, Voice};
-    use crate::contact::Address;
+    use crate::contact::{Address, InfoType};
     use crate::response::ResultCode;
     use crate::tests::{assert_serialized, response_from_file, CLTRID, SUCCESS_MSG, SVTRID};
 
@@ -121,7 +121,8 @@ mod tests {
             Some("392374"),
             "FR".parse().unwrap(),
         );
-        let postal_info = PostalInfo::new("loc", "John Doe", Some("Acme Widgets"), address);
+        let postal_info =
+            PostalInfo::new(InfoType::Local, "John Doe", Some("Acme Widgets"), address);
         let voice = Voice::new("+33.47237942");
 
         object.set_info("newemail@eppdev.net", postal_info, voice, "eppdev-387323");

--- a/src/extensions/frnic/mod.rs
+++ b/src/extensions/frnic/mod.rs
@@ -22,8 +22,8 @@ pub struct Create<T> {
 
 #[cfg(test)]
 mod tests {
-    use crate::contact::ContactCreate;
     use crate::contact::{Address, PostalInfo, Voice};
+    use crate::contact::{ContactCreate, InfoType};
     use crate::extensions::frnic;
     use crate::tests::assert_serialized;
     use frnic::{contact, Ext};
@@ -36,7 +36,7 @@ mod tests {
             "XXX000",
             "test@test.fr",
             PostalInfo::new(
-                "loc",
+                InfoType::Local,
                 "Dupont",
                 None,
                 Address::new(
@@ -66,7 +66,7 @@ mod tests {
             "XXXXXXX",
             "test@test.fr",
             PostalInfo::new(
-                "loc",
+                InfoType::Local,
                 "SARL DUPONT",
                 None,
                 Address::new(
@@ -100,7 +100,7 @@ mod tests {
             "XXXX0000",
             "test@test.fr",
             PostalInfo::new(
-                "loc",
+                InfoType::Local,
                 "SARL DUPONT SIREN",
                 None,
                 Address::new(
@@ -136,7 +136,7 @@ mod tests {
             "XXXX0000",
             "test@test.fr",
             PostalInfo::new(
-                "loc",
+                InfoType::Local,
                 "Dupont JO",
                 None,
                 Address::new(


### PR DESCRIPTION
From [RFC 5733 - EPP Contact Mapping](https://datatracker.ietf.org/doc/html/rfc5733#section-3.1.2):

"Two elements are provided so that address information can be
provided in both internationalized and localized forms ... If an
internationalized form (type="int") is provided, ... If a localized form
(type="loc") is provided ..."
