### PR TITLE
Make rustls connector more flexible

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -34,7 +34,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: "1.70.0"
+          toolchain: "1.71.0"
       - run: cargo check --lib --all-features
 
   lint:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,8 +9,8 @@ repository = "https://github.com/instant-labs/instant-epp"
 
 [features]
 default = ["rustls-aws-lc-rs"]
-rustls-aws-lc-rs = ["dep:tokio-rustls", "tokio-rustls/aws-lc-rs", "dep:rustls-native-certs"]
-rustls-ring = ["dep:tokio-rustls", "tokio-rustls/ring", "dep:rustls-native-certs"]
+rustls-aws-lc-rs = ["dep:tokio-rustls", "tokio-rustls/aws-lc-rs", "dep:rustls-platform-verifier"]
+rustls-ring = ["dep:tokio-rustls", "tokio-rustls/ring", "dep:rustls-platform-verifier"]
 __rustls = []
 
 [dependencies]
@@ -18,7 +18,7 @@ async-trait = "0.1.52"
 celes = "2.1"
 chrono = { version = "0.4.23", features = ["serde"] }
 instant-xml = { version = "0.5", features = ["chrono"] }
-rustls-native-certs = { version = "0.8", optional = true }
+rustls-platform-verifier = { version = "0.3", optional = true }
 serde = { version = "1.0", features = ["derive"] }
 tokio = { version = "1.0", features = ["io-util", "net", "time"] }
 tokio-rustls = { version = "0.26", optional = true, default-features = false, features = ["logging", "tls12"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ repository = "https://github.com/instant-labs/instant-epp"
 
 [features]
 default = ["rustls"]
-rustls = ["tokio-rustls", "rustls-pki-types", "rustls-native-certs"]
+rustls = ["tokio-rustls", "rustls-native-certs"]
 
 [dependencies]
 async-trait = "0.1.52"
@@ -17,7 +17,6 @@ celes = "2.1"
 chrono = { version = "0.4.23", features = ["serde"] }
 instant-xml = { version = "0.5", features = ["chrono"] }
 rustls-native-certs = { version = "0.8", optional = true }
-rustls-pki-types = { version = "1", optional = true }
 serde = { version = "1.0", features = ["derive"] }
 tokio = { version = "1.0", features = ["io-util", "net", "time"] }
 tokio-rustls = { version = "0.26", optional = true, default-features = false, features = ["logging", "ring", "tls12"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,8 +8,10 @@ description = "EPP client library for async Rust"
 repository = "https://github.com/instant-labs/instant-epp"
 
 [features]
-default = ["rustls"]
-rustls = ["tokio-rustls", "rustls-native-certs"]
+default = ["rustls-aws-lc-rs"]
+rustls-aws-lc-rs = ["dep:tokio-rustls", "tokio-rustls/aws-lc-rs", "dep:rustls-native-certs"]
+rustls-ring = ["dep:tokio-rustls", "tokio-rustls/ring", "dep:rustls-native-certs"]
+__rustls = []
 
 [dependencies]
 async-trait = "0.1.52"
@@ -19,7 +21,7 @@ instant-xml = { version = "0.5", features = ["chrono"] }
 rustls-native-certs = { version = "0.8", optional = true }
 serde = { version = "1.0", features = ["derive"] }
 tokio = { version = "1.0", features = ["io-util", "net", "time"] }
-tokio-rustls = { version = "0.26", optional = true, default-features = false, features = ["logging", "ring", "tls12"] }
+tokio-rustls = { version = "0.26", optional = true, default-features = false, features = ["logging", "tls12"] }
 tracing = "0.1.29"
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "instant-epp"
 version = "0.5.0"
 edition = "2021"
-rust-version = "1.70"
+rust-version = "1.71"
 license = "MIT"
 description = "EPP client library for async Rust"
 repository = "https://github.com/instant-labs/instant-epp"

--- a/deny.toml
+++ b/deny.toml
@@ -4,6 +4,7 @@ allow = [
     "BSD-3-Clause",
     "ISC",
     "MIT",
+    "MPL-2.0",
     "OpenSSL",
     "Unicode-DFS-2016",
 ]

--- a/src/client.rs
+++ b/src/client.rs
@@ -85,7 +85,7 @@ impl EppClient<RustlsConnector> {
         identity: Option<(Vec<CertificateDer<'static>>, PrivateKeyDer<'static>)>,
         timeout: Duration,
     ) -> Result<Self, Error> {
-        let connector = RustlsConnector::new(server, identity).await?;
+        let connector = RustlsConnector::new(server, identity)?;
         Self::new(connector, registry, timeout).await
     }
 }
@@ -234,7 +234,7 @@ mod rustls_connector {
     }
 
     impl RustlsConnector {
-        pub async fn new(
+        pub fn new(
             server: (String, u16),
             identity: Option<(Vec<CertificateDer<'static>>, PrivateKeyDer<'static>)>,
         ) -> Result<Self, Error> {

--- a/src/client.rs
+++ b/src/client.rs
@@ -229,7 +229,7 @@ mod rustls_connector {
 
     pub struct RustlsConnector {
         inner: TlsConnector,
-        domain: ServerName<'static>,
+        server_name: ServerName<'static>,
         server: (String, u16),
     }
 
@@ -261,7 +261,7 @@ mod rustls_connector {
                 None => builder.with_no_client_auth(),
             };
 
-            let domain = ServerName::try_from(server.0.as_str())
+            let server_name = ServerName::try_from(server.0.as_str())
                 .map_err(|_| {
                     io::Error::new(
                         io::ErrorKind::InvalidInput,
@@ -272,7 +272,7 @@ mod rustls_connector {
 
             Ok(Self {
                 inner: TlsConnector::from(Arc::new(config)),
-                domain,
+                server_name,
                 server,
             })
         }
@@ -295,7 +295,7 @@ mod rustls_connector {
             };
 
             let stream = TcpStream::connect(addr).await?;
-            let future = self.inner.connect(self.domain.clone(), stream);
+            let future = self.inner.connect(self.server_name.clone(), stream);
             connection::timeout(timeout, future).await
         }
     }

--- a/src/client.rs
+++ b/src/client.rs
@@ -283,13 +283,13 @@ mod rustls_connector {
         type Connection = TlsStream<TcpStream>;
 
         async fn connect(&self, timeout: Duration) -> Result<Self::Connection, Error> {
-            info!("Connecting to server: {}:{}", self.server.0, self.server.1);
+            info!("connecting to server: {}:{}", self.server.0, self.server.1);
             let addr = match lookup_host(&self.server).await?.next() {
                 Some(addr) => addr,
                 None => {
                     return Err(Error::Io(io::Error::new(
                         io::ErrorKind::InvalidInput,
-                        format!("Invalid host: {}", &self.server.0),
+                        format!("invalid host: {}", &self.server.0),
                     )))
                 }
             };

--- a/src/client.rs
+++ b/src/client.rs
@@ -1,7 +1,7 @@
 use std::time::Duration;
 
 #[cfg(feature = "rustls")]
-use rustls_pki_types::{CertificateDer, PrivateKeyDer};
+use tokio_rustls::rustls::pki_types::{CertificateDer, PrivateKeyDer};
 use tracing::{debug, error};
 
 use crate::common::NoExtension;
@@ -216,10 +216,10 @@ mod rustls_connector {
 
     use async_trait::async_trait;
     use rustls_native_certs::CertificateResult;
-    use rustls_pki_types::{CertificateDer, PrivateKeyDer, ServerName};
     use tokio::net::lookup_host;
     use tokio::net::TcpStream;
     use tokio_rustls::client::TlsStream;
+    use tokio_rustls::rustls::pki_types::{CertificateDer, PrivateKeyDer, ServerName};
     use tokio_rustls::rustls::{ClientConfig, RootCertStore};
     use tokio_rustls::TlsConnector;
     use tracing::info;

--- a/src/client.rs
+++ b/src/client.rs
@@ -247,13 +247,10 @@ mod rustls_connector {
             }
 
             for cert in certs {
-                roots.add(cert).map_err(|err| {
-                    Box::new(err) as Box<dyn std::error::Error + Send + Sync + 'static>
-                })?;
+                roots.add(cert).map_err(|err| Error::Other(err.into()))?;
             }
 
             let builder = ClientConfig::builder().with_root_certificates(roots);
-
             let config = match identity {
                 Some((certs, key)) => builder
                     .with_client_auth_cert(certs, key)
@@ -262,12 +259,7 @@ mod rustls_connector {
             };
 
             let server_name = ServerName::try_from(server.0.as_str())
-                .map_err(|_| {
-                    io::Error::new(
-                        io::ErrorKind::InvalidInput,
-                        format!("invalid domain: {}", server.0),
-                    )
-                })?
+                .map_err(|err| Error::Other(err.into()))?
                 .to_owned();
 
             Ok(Self {

--- a/src/client.rs
+++ b/src/client.rs
@@ -1,6 +1,6 @@
 use std::time::Duration;
 
-#[cfg(feature = "rustls")]
+#[cfg(feature = "__rustls")]
 use tokio_rustls::rustls::pki_types::{CertificateDer, PrivateKeyDer};
 use tracing::{debug, error};
 
@@ -68,7 +68,7 @@ pub struct EppClient<C: Connector> {
     connection: EppConnection<C>,
 }
 
-#[cfg(feature = "rustls")]
+#[cfg(feature = "__rustls")]
 impl EppClient<RustlsConnector> {
     /// Connect to the specified `addr` and `hostname` over TLS
     ///
@@ -205,10 +205,10 @@ impl<C, E> Clone for RequestData<'_, '_, C, E> {
 // Manual impl because this does not depend on whether `C` and `E` are `Copy`
 impl<C, E> Copy for RequestData<'_, '_, C, E> {}
 
-#[cfg(feature = "rustls")]
+#[cfg(feature = "__rustls")]
 pub use rustls_connector::RustlsConnector;
 
-#[cfg(feature = "rustls")]
+#[cfg(feature = "__rustls")]
 mod rustls_connector {
     use std::io;
     use std::sync::Arc;


### PR DESCRIPTION
@Morpheus9 this is my proposed alternative to #58. I think that code is a bit messy, and I don't think this project should carry around unsafe verifier implementations. Using the API proposed in this PR, it should be possible to plug in alternative verifiers in your downstream project.

Curious to hear your use case -- would be cool if your organization could sponsor continued maintenance of instant-epp.