### PR TITLE
Connection level extensions

### DIFF
--- a/src/extensions/change_poll.rs
+++ b/src/extensions/change_poll.rs
@@ -3,33 +3,31 @@
 //! As described in RFC8590: [Change Poll Extension for the Extensible Provisioning Protocol (EPP)](https://www.rfc-editor.org/rfc/rfc8590.html).
 //! Tests cases in `tests/resources/response/extensions/changepoll`` are taken from the RFC.
 
-use std::borrow::Cow;
-
 use instant_xml::{Error, FromXml, ToXml};
 
 use crate::response::ConnectionExtensionResponse;
 
 pub const XMLNS: &str = "urn:ietf:params:xml:ns:changePoll-1.0";
 
-impl ConnectionExtensionResponse for ChangePoll<'_> {}
+impl ConnectionExtensionResponse for ChangePoll {}
 
 /// Type for EPP XML `<changePoll>` extension
 ///
 /// Attributes associated with the change
 #[derive(Debug, FromXml, ToXml)]
 #[xml(rename = "changeData", ns(XMLNS))]
-pub struct ChangePoll<'a> {
+pub struct ChangePoll {
     /// Transform operation executed on the object
-    pub operation: Operation<'a>,
+    pub operation: Operation,
     /// Date and time when the operation was executed
-    pub date: Cow<'a, str>,
+    pub date: String,
     /// Server transaction identifier of the operation
     #[xml(rename = "svTRID")]
-    pub server_tr_id: Cow<'a, str>,
+    pub server_tr_id: String,
     /// Who executed the operation
-    pub who: Cow<'a, str>,
+    pub who: String,
     /// Case identifier associated with the operation
-    pub case_id: Option<CaseIdentifier<'a>>,
+    pub case_id: Option<CaseIdentifier>,
     /// Reason for executing the operation
     pub reason: Option<Reason>,
     /// Enumerated state of the object in the poll message
@@ -39,7 +37,7 @@ pub struct ChangePoll<'a> {
     state: Option<State>,
 }
 
-impl ChangePoll<'_> {
+impl ChangePoll {
     /// State reflects if the `infData` describes the object before or after the operation
     pub fn state(&self) -> State {
         self.state.unwrap_or_default()
@@ -51,16 +49,16 @@ impl ChangePoll<'_> {
 // to make this struct more ergonomic.
 #[derive(Debug, FromXml, ToXml)]
 #[xml(rename = "operation", ns(XMLNS))]
-pub struct Operation<'a> {
+pub struct Operation {
     /// Custom value for`OperationKind::Custom`
     #[xml(attribute, rename = "op")]
-    op: Option<Cow<'a, str>>,
+    op: Option<String>,
     /// The operation
     #[xml(direct)]
     kind: OperationType,
 }
 
-impl Operation<'_> {
+impl Operation {
     pub fn kind(&self) -> Result<OperationKind, Error> {
         Ok(match self.kind {
             OperationType::Create => OperationKind::Create,
@@ -121,16 +119,16 @@ enum OperationType {
 // to make this struct more ergonomic.
 #[derive(Debug, FromXml, ToXml)]
 #[xml(rename = "caseId", ns(XMLNS))]
-pub struct CaseIdentifier<'a> {
+pub struct CaseIdentifier {
     #[xml(attribute, rename = "type")]
     id_type: CaseIdentifierType,
     #[xml(attribute)]
-    name: Option<Cow<'a, str>>,
+    name: Option<String>,
     #[xml(direct)]
-    pub id: Cow<'a, str>,
+    pub id: String,
 }
 
-impl CaseIdentifier<'_> {
+impl CaseIdentifier {
     pub fn kind(&self) -> Result<CaseIdentifierKind, Error> {
         Ok(match self.id_type {
             CaseIdentifierType::Udrp => CaseIdentifierKind::Udrp,

--- a/src/extensions/namestore.rs
+++ b/src/extensions/namestore.rs
@@ -75,6 +75,7 @@ pub struct NameStore<'a> {
 #[cfg(test)]
 mod tests {
     use super::NameStore;
+    use crate::common::NoExtension;
     use crate::domain::check::DomainCheck;
     use crate::tests::{assert_serialized, response_from_file_with_ext};
 
@@ -94,10 +95,10 @@ mod tests {
 
     #[test]
     fn response() {
-        let object = response_from_file_with_ext::<DomainCheck, NameStore>(
+        let object = response_from_file_with_ext::<DomainCheck, NameStore, NoExtension>(
             "response/extensions/namestore.xml",
         );
-        let ext = object.extension().unwrap();
+        let ext = &object.command_extension().unwrap();
         assert_eq!(ext.subproduct, "com");
     }
 }

--- a/src/extensions/rgp/request.rs
+++ b/src/extensions/rgp/request.rs
@@ -69,6 +69,7 @@ pub enum RgpRequestResponse {
 #[cfg(test)]
 mod tests {
     use super::{RgpRestoreRequest, Update};
+    use crate::common::NoExtension;
     use crate::domain::info::DomainInfo;
     use crate::domain::update::{DomainChangeInfo, DomainUpdate};
     use crate::extensions::rgp::request::RgpRequestResponse;
@@ -99,15 +100,16 @@ mod tests {
 
     #[test]
     fn request_response() {
-        let object = response_from_file_with_ext::<DomainUpdate, Update<RgpRestoreRequest>>(
-            "response/extensions/rgp_restore.xml",
-        );
-        let ext = object.extension.unwrap();
+        let object =
+            response_from_file_with_ext::<DomainUpdate, Update<RgpRestoreRequest>, NoExtension>(
+                "response/extensions/rgp_restore.xml",
+            );
+        let ext = object.command_extension().unwrap();
 
         assert_eq!(object.result.code, ResultCode::CommandCompletedSuccessfully);
         assert_eq!(object.result.message, SUCCESS_MSG);
 
-        let data = match ext.data {
+        let data = match ext {
             RgpRequestResponse::Update(data) => data,
             _ => panic!("Unexpected response type"),
         };
@@ -118,12 +120,13 @@ mod tests {
 
     #[test]
     fn domain_info_request_response() {
-        let object = response_from_file_with_ext::<DomainInfo, Update<RgpRestoreRequest>>(
-            "response/extensions/domain_info_rgp.xml",
-        );
-        let ext = object.extension.unwrap();
+        let object =
+            response_from_file_with_ext::<DomainInfo, Update<RgpRestoreRequest>, NoExtension>(
+                "response/extensions/domain_info_rgp.xml",
+            );
+        let ext = object.command_extension().unwrap();
 
-        let data = match ext.data {
+        let data = match ext {
             RgpRequestResponse::Info(data) => data,
             _ => panic!("Unexpected response type"),
         };

--- a/src/response.rs
+++ b/src/response.rs
@@ -321,6 +321,8 @@ pub trait ConnectionExtensionResponse: FromXmlOwned + Debug {}
 
 impl ConnectionExtensionResponse for NoExtension {}
 
+impl<T: ConnectionExtensionResponse> ConnectionExtensionResponse for Option<T> {}
+
 /// Combines connection extensions and command extensions
 ///
 /// Some extensions are sent by the server no matter if an extension was defined for the command.

--- a/src/response.rs
+++ b/src/response.rs
@@ -3,9 +3,9 @@
 use std::fmt::Debug;
 
 use chrono::{DateTime, Utc};
-use instant_xml::{FromXml, Kind};
+use instant_xml::{Deserializer, FromXml, FromXmlOwned, Id, Kind};
 
-use crate::common::EPP_XMLNS;
+use crate::common::{NoExtension, EPP_XMLNS};
 
 /// Type corresponding to the `<undef>` tag an EPP response XML
 #[derive(Debug, Eq, FromXml, PartialEq)]
@@ -238,7 +238,7 @@ pub struct Message {
 /// Type corresponding to the `<response>` tag in an EPP response XML
 /// containing an `<extension>` tag
 #[xml(rename = "response", ns(EPP_XMLNS))]
-pub struct Response<D, E> {
+pub struct Response<D, CmdExt, ConnExt> {
     /// Data under the `<result>` tag
     pub result: EppResult,
     /// Data under the `<msgQ>` tag
@@ -247,7 +247,7 @@ pub struct Response<D, E> {
     /// Data under the `<resData>` tag
     pub res_data: Option<ResponseData<D>>,
     /// Data under the `<extension>` tag
-    pub extension: Option<Extension<E>>,
+    pub extension: Option<Extension<CmdExt, ConnExt>>,
     /// Data under the `<trID>` tag
     pub tr_ids: ResponseTRID,
 }
@@ -276,7 +276,7 @@ pub struct ResponseStatus {
     pub tr_ids: ResponseTRID,
 }
 
-impl<T, E> Response<T, E> {
+impl<T, CmdExt, ConnExt> Response<T, CmdExt, ConnExt> {
     /// Returns the data under the corresponding `<resData>` from the EPP XML
     pub fn res_data(&self) -> Option<&T> {
         match &self.res_data {
@@ -285,9 +285,16 @@ impl<T, E> Response<T, E> {
         }
     }
 
-    pub fn extension(&self) -> Option<&E> {
+    pub fn command_extension(&self) -> Option<&CmdExt> {
         match &self.extension {
-            Some(extension) => Some(&extension.data),
+            Some(extension) => extension.data.command.as_ref(),
+            None => None,
+        }
+    }
+
+    pub fn connection_extension(&self) -> Option<&ConnExt> {
+        match &self.extension {
+            Some(extension) => extension.data.connection.as_ref(),
             None => None,
         }
     }
@@ -303,8 +310,116 @@ impl<T, E> Response<T, E> {
 
 #[derive(Debug, Eq, FromXml, PartialEq)]
 #[xml(rename = "extension", ns(EPP_XMLNS))]
-pub struct Extension<E> {
-    pub data: E,
+pub struct Extension<CmdExt, ConnExt> {
+    pub data: CombinedExtensions<CmdExt, ConnExt>,
+}
+
+/// Types implementing this can be used as ConnectionExtensions.
+///
+/// Their type will be assumed to be in the response's extension element.
+pub trait ConnectionExtensionResponse: FromXmlOwned + Debug {}
+
+impl ConnectionExtensionResponse for NoExtension {}
+
+/// Combines connection extensions and command extensions
+///
+/// Some extensions are sent by the server no matter if an extension was defined for the command.
+#[derive(Debug, Eq, PartialEq)]
+pub struct CombinedExtensions<CmdExt, ConnExt> {
+    pub command: Option<CmdExt>,
+    pub connection: Option<ConnExt>,
+}
+
+// // This manual impl is needed because instant-xml is not able to create the correct derived impl.
+// // for this transparent type. It fails to set the correct bounds for struct __CombinedExtensionsAccumulator.
+impl<'xml, CmdExt: FromXml<'xml>, ConnExt: FromXml<'xml>> FromXml<'xml>
+    for CombinedExtensions<CmdExt, ConnExt>
+{
+    #[inline]
+    fn matches(id: Id<'_>, _: Option<Id<'_>>) -> bool {
+        <CmdExt as FromXml<'xml>>::matches(id, None)
+            || <ConnExt as FromXml<'xml>>::matches(id, None)
+    }
+    fn deserialize<'cx>(
+        into: &mut Self::Accumulator,
+        _: &'static str,
+        deserializer: &mut Deserializer<'cx, 'xml>,
+    ) -> Result<(), instant_xml::Error> {
+        use instant_xml::Kind;
+        let current = deserializer.parent();
+        if <CmdExt as FromXml<'xml>>::matches(current, None) {
+            match <CmdExt as FromXml>::KIND {
+                Kind::Element => {
+                    <Option<CmdExt>>::deserialize(
+                        &mut into.command,
+                        "CombinedExtensions::command",
+                        deserializer,
+                    )?;
+                }
+                Kind::Scalar => {
+                    <Option<CmdExt>>::deserialize(
+                        &mut into.command,
+                        "CombinedExtensions::command",
+                        deserializer,
+                    )?;
+                    deserializer.ignore()?;
+                }
+            }
+        } else if <ConnExt as FromXml<'xml>>::matches(current, None) {
+            match <ConnExt as FromXml>::KIND {
+                Kind::Element => {
+                    <Option<ConnExt>>::deserialize(
+                        &mut into.connection,
+                        "CombinedExtensions::connection",
+                        deserializer,
+                    )?;
+                }
+                Kind::Scalar => {
+                    <Option<ConnExt>>::deserialize(
+                        &mut into.connection,
+                        "CombinedExtensions::connection",
+                        deserializer,
+                    )?;
+                    deserializer.ignore()?;
+                }
+            }
+        }
+        Ok(())
+    }
+    type Accumulator = __CombinedExtensionsAccumulator<'xml, CmdExt, ConnExt>;
+    const KIND: instant_xml::Kind = instant_xml::Kind::Element;
+}
+
+pub struct __CombinedExtensionsAccumulator<'xml, CommandExt: FromXml<'xml>, ConnExt: FromXml<'xml>>
+{
+    command: <Option<CommandExt> as FromXml<'xml>>::Accumulator,
+    connection: <Option<ConnExt> as FromXml<'xml>>::Accumulator,
+}
+
+impl<'xml, CommandExt: FromXml<'xml>, ConnExt: FromXml<'xml>>
+    instant_xml::Accumulate<CombinedExtensions<CommandExt, ConnExt>>
+    for __CombinedExtensionsAccumulator<'xml, CommandExt, ConnExt>
+{
+    fn try_done(
+        self,
+        _: &'static str,
+    ) -> Result<CombinedExtensions<CommandExt, ConnExt>, instant_xml::Error> {
+        Ok(CombinedExtensions {
+            command: self.command.try_done("CombinedExtensions::command")?,
+            connection: self.connection.try_done("CombinedExtensions::connection")?,
+        })
+    }
+}
+
+impl<'xml, CommandExt: FromXml<'xml>, ConnExt: instant_xml::FromXml<'xml>> Default
+    for __CombinedExtensionsAccumulator<'xml, CommandExt, ConnExt>
+{
+    fn default() -> Self {
+        Self {
+            command: Default::default(),
+            connection: Default::default(),
+        }
+    }
 }
 
 #[cfg(test)]

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -9,7 +9,7 @@ use crate::{
     client::RequestData,
     common::NoExtension,
     request::{Command, CommandWrapper, Extension, Transaction},
-    response::Response,
+    response::{ConnectionExtensionResponse, Response},
     xml,
 };
 
@@ -53,23 +53,24 @@ pub(crate) fn assert_serialized<'c, 'e, Cmd, Ext>(
 
 pub(crate) fn response_from_file<'c, Cmd>(
     path: &str,
-) -> Response<Cmd::Response, <NoExtension as Extension>::Response>
+) -> Response<Cmd::Response, <NoExtension as Extension>::Response, NoExtension>
 where
     Cmd: Transaction<NoExtension> + Command + 'c,
 {
-    response_from_file_with_ext::<Cmd, NoExtension>(path)
+    response_from_file_with_ext::<Cmd, NoExtension, NoExtension>(path)
 }
 
-pub(crate) fn response_from_file_with_ext<Cmd, Ext>(
+pub(crate) fn response_from_file_with_ext<Cmd, CmdExt, ConnExt>(
     path: &str,
-) -> Response<Cmd::Response, Ext::Response>
+) -> Response<Cmd::Response, CmdExt::Response, ConnExt>
 where
     Cmd: Transaction<NoExtension> + Command,
-    Ext: Extension,
+    CmdExt: Extension,
+    ConnExt: ConnectionExtensionResponse,
 {
     let xml = get_xml(path).unwrap();
     dbg!(&xml);
-    let rsp = xml::deserialize::<Response<Cmd::Response, Ext::Response>>(&xml).unwrap();
+    let rsp = xml::deserialize::<Response<Cmd::Response, CmdExt::Response, ConnExt>>(&xml).unwrap();
     assert!(rsp.result.code.is_success());
     rsp
 }


### PR DESCRIPTION
Some EPP extensions such as change poll didn't map to the present command oriented extensions. My last PR #60 contained some errors, making it non-working in real life.

Looking at the change poll extension:
The <changePoll> element will be present in the poll response's <extension> tag without any elements in the <extension> element of the request.
There is, in fact, no allowed value for the <extension> element for the poll command (if you only support RGP, NameStore, and ChangePoll). This makes it impossible to encode the `ChangePoll` response in any call to `transact` currently.

This now stores enabled general extensions in the EppClient. This allows you to retrieve command level extensions responses using `Response::command_extension` and connection level extensions using Response::connection_extension.

I am not totally happy with this, as it assumes these might be present for all commands. (Adding the need to use Option<ChangePoll> downstream). Adding yet another `Transaction` like trait seems suboptimal, as `Transaction` already caused some downstream pain, if you remember. 

This probably needs some work before it is good enough for a merge.