### PR TITLE
Drop scheduled CI runs

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -4,8 +4,6 @@ on:
   push:
     branches: ['main']
   pull_request:
-  schedule:
-    - cron: '17 6 * * 5'
 
 jobs:
   test:


### PR DESCRIPTION
Avoids CI being disabled while this repository is not so active.